### PR TITLE
fix: scale up prompt UI controls to fill panel

### DIFF
--- a/Sources/Pane/Views/ExtendPresetDiagram.swift
+++ b/Sources/Pane/Views/ExtendPresetDiagram.swift
@@ -1,43 +1,84 @@
 import SwiftUI
 
 /// Canvas-rendered diagram showing a display arrangement preset.
-///
-/// See pane-spec Section 11. Uses SwiftUI Canvas to avoid asset maintenance
-/// as selection state changes colours dynamically.
 struct ExtendPresetDiagram: View {
 
     let preset: DisplayConfiguration.ExtendPreset
     let isSelected: Bool
 
+    private let macBookSize = CGSize(width: 44, height: 30)
+    private let externalSize = CGSize(width: 52, height: 36)
+    private let cornerRadius: CGFloat = 4
+    private let gap: CGFloat = 4
+
     var body: some View {
         Canvas { context, size in
-            // TODO: Phase 2 — Draw MacBook rect (grey) + external rect
-            //   - External: blue tint if selected, grey if not
-            //   - Position based on preset (.externalRight, .externalLeft, .externalAbove)
-            let macBookRect = CGRect(x: 0, y: 0, width: 30, height: 20)
+            let midX = size.width / 2
+            let midY = size.height / 2
             let externalColor: Color = isSelected ? .accentColor : .secondary
 
             switch preset {
             case .externalRight:
-                context.fill(Path(macBookRect.offsetBy(dx: 0, dy: 7)), with: .color(.secondary))
-                context.fill(
-                    Path(CGRect(x: 32, y: 0, width: 30, height: 34)),
-                    with: .color(externalColor.opacity(0.6))
+                let totalWidth = macBookSize.width + gap + externalSize.width
+                let startX = midX - totalWidth / 2
+                let macRect = CGRect(
+                    x: startX,
+                    y: midY - macBookSize.height / 2,
+                    width: macBookSize.width,
+                    height: macBookSize.height
                 )
+                let extRect = CGRect(
+                    x: startX + macBookSize.width + gap,
+                    y: midY - externalSize.height / 2,
+                    width: externalSize.width,
+                    height: externalSize.height
+                )
+                drawDisplay(context: context, rect: macRect, color: .secondary, radius: cornerRadius)
+                drawDisplay(context: context, rect: extRect, color: externalColor, radius: cornerRadius)
+
             case .externalLeft:
-                context.fill(
-                    Path(CGRect(x: 0, y: 0, width: 30, height: 34)),
-                    with: .color(externalColor.opacity(0.6))
+                let totalWidth = externalSize.width + gap + macBookSize.width
+                let startX = midX - totalWidth / 2
+                let extRect = CGRect(
+                    x: startX,
+                    y: midY - externalSize.height / 2,
+                    width: externalSize.width,
+                    height: externalSize.height
                 )
-                context.fill(Path(macBookRect.offsetBy(dx: 32, dy: 7)), with: .color(.secondary))
+                let macRect = CGRect(
+                    x: startX + externalSize.width + gap,
+                    y: midY - macBookSize.height / 2,
+                    width: macBookSize.width,
+                    height: macBookSize.height
+                )
+                drawDisplay(context: context, rect: extRect, color: externalColor, radius: cornerRadius)
+                drawDisplay(context: context, rect: macRect, color: .secondary, radius: cornerRadius)
+
             case .externalAbove:
-                context.fill(
-                    Path(CGRect(x: 0, y: 0, width: 30, height: 14)),
-                    with: .color(externalColor.opacity(0.6))
+                let totalHeight = externalSize.height + gap + macBookSize.height
+                let startY = midY - totalHeight / 2
+                let extRect = CGRect(
+                    x: midX - externalSize.width / 2,
+                    y: startY,
+                    width: externalSize.width,
+                    height: externalSize.height
                 )
-                context.fill(Path(macBookRect.offsetBy(dx: 0, dy: 16)), with: .color(.secondary))
+                let macRect = CGRect(
+                    x: midX - macBookSize.width / 2,
+                    y: startY + externalSize.height + gap,
+                    width: macBookSize.width,
+                    height: macBookSize.height
+                )
+                drawDisplay(context: context, rect: extRect, color: externalColor, radius: cornerRadius)
+                drawDisplay(context: context, rect: macRect, color: .secondary, radius: cornerRadius)
             }
         }
-        .frame(width: 64, height: 34)
+        .frame(width: 120, height: 80)
+    }
+
+    private func drawDisplay(context: GraphicsContext, rect: CGRect, color: Color, radius: CGFloat) {
+        let path = RoundedRectangle(cornerRadius: radius).path(in: rect)
+        context.fill(path, with: .color(color.opacity(0.5)))
+        context.stroke(path, with: .color(color.opacity(0.8)), lineWidth: 1.5)
     }
 }

--- a/Sources/Pane/Views/ExtendView.swift
+++ b/Sources/Pane/Views/ExtendView.swift
@@ -1,39 +1,34 @@
 import SwiftUI
 
 /// Extend mode tab: three preset cards showing display arrangement options.
-///
-/// See pane-spec Section 7 (ExtendView).
 struct ExtendView: View {
 
     @Binding var selectedPreset: DisplayConfiguration.ExtendPreset
 
     var body: some View {
-        // TODO: Phase 2 — HStack of three preset cards:
-        //   - Each card: ExtendPresetDiagram + label
-        //   - Selected: 1.5pt blue border + light blue tint
-        HStack(spacing: 12) {
+        HStack(spacing: 24) {
             ForEach(DisplayConfiguration.ExtendPreset.allCases, id: \.self) { preset in
                 Button {
                     selectedPreset = preset
                 } label: {
-                    VStack(spacing: 8) {
+                    VStack(spacing: 14) {
                         ExtendPresetDiagram(
                             preset: preset,
                             isSelected: selectedPreset == preset
                         )
                         Text(preset.displayName)
-                            .font(.caption)
+                            .font(.system(size: 16, weight: .medium))
                     }
-                    .padding(8)
+                    .frame(width: 160, height: 140)
                     .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(selectedPreset == preset ? Color.accentColor.opacity(0.1) : Color.clear)
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(selectedPreset == preset ? Color.accentColor.opacity(0.12) : Color.secondary.opacity(0.08))
                     )
                     .overlay(
-                        RoundedRectangle(cornerRadius: 8)
+                        RoundedRectangle(cornerRadius: 12)
                             .stroke(
                                 selectedPreset == preset ? Color.accentColor : Color.clear,
-                                lineWidth: 1.5
+                                lineWidth: 2
                             )
                     )
                 }

--- a/Sources/Pane/Views/MirrorView.swift
+++ b/Sources/Pane/Views/MirrorView.swift
@@ -1,45 +1,103 @@
 import SwiftUI
 
 /// Mirror mode tab: two option cards for mirror target selection.
-///
-/// See pane-spec Section 7 (MirrorView).
 struct MirrorView: View {
 
     @Binding var selectedMirrorTarget: DisplayConfiguration.MirrorTarget
 
     var body: some View {
-        // TODO: Phase 2 — HStack of two option cards:
-        //   - "Optimise for MacBook" / "Optimise for external"
-        //   - Diagram showing active/dimmed display
-        //   - Subtitle with resolution implication
-        HStack(spacing: 12) {
+        HStack(spacing: 24) {
             ForEach(DisplayConfiguration.MirrorTarget.allCases, id: \.self) { target in
                 Button {
                     selectedMirrorTarget = target
                 } label: {
-                    VStack(spacing: 8) {
-                        // TODO: Phase 2 — Mirror diagram
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color.secondary.opacity(0.2))
-                            .frame(width: 64, height: 34)
-                        Text(target.displayName)
-                            .font(.caption)
+                    VStack(spacing: 14) {
+                        MirrorDiagram(target: target, isSelected: selectedMirrorTarget == target)
+                        VStack(spacing: 4) {
+                            Text(target.displayName)
+                                .font(.system(size: 16, weight: .medium))
+                            Text(target.subtitle)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        }
                     }
-                    .padding(8)
+                    .frame(width: 200, height: 140)
                     .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(selectedMirrorTarget == target ? Color.accentColor.opacity(0.1) : Color.clear)
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(selectedMirrorTarget == target ? Color.accentColor.opacity(0.12) : Color.secondary.opacity(0.08))
                     )
                     .overlay(
-                        RoundedRectangle(cornerRadius: 8)
+                        RoundedRectangle(cornerRadius: 12)
                             .stroke(
                                 selectedMirrorTarget == target ? Color.accentColor : Color.clear,
-                                lineWidth: 1.5
+                                lineWidth: 2
                             )
                     )
                 }
                 .buttonStyle(.plain)
             }
+        }
+    }
+}
+
+/// Canvas diagram for mirror mode showing active/dimmed displays.
+struct MirrorDiagram: View {
+    let target: DisplayConfiguration.MirrorTarget
+    let isSelected: Bool
+
+    var body: some View {
+        Canvas { context, size in
+            let midX = size.width / 2
+            let midY = size.height / 2
+            let displaySize = CGSize(width: 48, height: 32)
+            let overlap: CGFloat = 16
+
+            let backRect = CGRect(
+                x: midX - overlap / 2 - displaySize.width / 2,
+                y: midY - displaySize.height / 2 - 4,
+                width: displaySize.width,
+                height: displaySize.height
+            )
+            let frontRect = CGRect(
+                x: midX + overlap / 2 - displaySize.width / 2,
+                y: midY - displaySize.height / 2 + 4,
+                width: displaySize.width,
+                height: displaySize.height
+            )
+
+            let activeColor: Color = isSelected ? .accentColor : .secondary
+            let dimmedOpacity: Double = 0.25
+            let activeOpacity: Double = 0.6
+
+            switch target {
+            case .macBook:
+                // External is dimmed (back), MacBook is active (front)
+                let backPath = RoundedRectangle(cornerRadius: 3).path(in: backRect)
+                context.fill(backPath, with: .color(.secondary.opacity(dimmedOpacity)))
+                context.stroke(backPath, with: .color(.secondary.opacity(0.4)), lineWidth: 1)
+                let frontPath = RoundedRectangle(cornerRadius: 3).path(in: frontRect)
+                context.fill(frontPath, with: .color(activeColor.opacity(activeOpacity)))
+                context.stroke(frontPath, with: .color(activeColor.opacity(0.8)), lineWidth: 1.5)
+
+            case .external:
+                // MacBook is dimmed (back), external is active (front)
+                let backPath = RoundedRectangle(cornerRadius: 3).path(in: backRect)
+                context.fill(backPath, with: .color(.secondary.opacity(dimmedOpacity)))
+                context.stroke(backPath, with: .color(.secondary.opacity(0.4)), lineWidth: 1)
+                let frontPath = RoundedRectangle(cornerRadius: 3).path(in: frontRect)
+                context.fill(frontPath, with: .color(activeColor.opacity(activeOpacity)))
+                context.stroke(frontPath, with: .color(activeColor.opacity(0.8)), lineWidth: 1.5)
+            }
+        }
+        .frame(width: 120, height: 60)
+    }
+}
+
+extension DisplayConfiguration.MirrorTarget {
+    var subtitle: String {
+        switch self {
+        case .macBook: "Uses MacBook resolution"
+        case .external: "Uses external resolution"
         }
     }
 }

--- a/Sources/Pane/Views/PromptView.swift
+++ b/Sources/Pane/Views/PromptView.swift
@@ -32,26 +32,22 @@ struct PromptView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            Spacer()
+
             // Header
-            HStack(spacing: 14) {
+            VStack(spacing: 8) {
                 Image(systemName: "display")
-                    .font(.system(size: 36))
+                    .font(.system(size: 48, weight: .light))
                     .foregroundStyle(.secondary)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(displayName)
-                        .font(.system(size: 20, weight: .semibold))
-                    Text("\(Int(resolution.width))×\(Int(resolution.height))")
-                        .font(.system(size: 14))
-                        .foregroundStyle(.secondary)
-                }
+                Text(displayName)
+                    .font(.system(size: 28, weight: .semibold))
 
-                Spacer()
+                Text("\(Int(resolution.width))×\(Int(resolution.height))")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.secondary)
             }
-            .padding(.horizontal, 32)
-            .padding(.vertical, 24)
-
-            Divider()
+            .padding(.bottom, 32)
 
             // Mode picker
             Picker("Mode", selection: $selectedMode) {
@@ -60,10 +56,10 @@ struct PromptView: View {
             }
             .pickerStyle(.segmented)
             .labelsHidden()
-            .padding(.horizontal, 32)
-            .padding(.vertical, 20)
+            .frame(width: 240)
+            .padding(.bottom, 32)
 
-            // Mode content — expanded to fill
+            // Mode content
             Group {
                 switch selectedMode {
                 case .extend:
@@ -72,40 +68,39 @@ struct PromptView: View {
                     MirrorView(selectedMirrorTarget: $selectedMirrorTarget)
                 }
             }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 32)
-            .padding(.bottom, 20)
 
-            Divider()
+            Spacer()
 
             // Remember checkbox
-            HStack {
-                Toggle("Remember for this display", isOn: $rememberDisplay)
-                    .toggleStyle(.checkbox)
-                    .font(.system(size: 13))
-                Spacer()
-            }
-            .padding(.horizontal, 32)
-            .padding(.vertical, 16)
+            Toggle("Remember for this display", isOn: $rememberDisplay)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 15))
+                .padding(.bottom, 24)
 
-            Divider()
-
-            // Action buttons — centred on their own row
-            HStack(spacing: 16) {
-                Button("Dismiss") {
+            // Action buttons
+            HStack(spacing: 20) {
+                Button {
                     onDismiss()
+                } label: {
+                    Text("Dismiss")
+                        .frame(width: 120, height: 36)
                 }
                 .keyboardShortcut(.cancelAction)
                 .controlSize(.large)
 
-                Button("Apply") {
+                Button {
                     applyConfiguration()
+                } label: {
+                    Text("Apply")
+                        .frame(width: 120, height: 36)
                 }
                 .keyboardShortcut(.defaultAction)
                 .controlSize(.large)
+                .buttonStyle(.borderedProminent)
             }
-            .padding(.vertical, 20)
+            .padding(.bottom, 32)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func applyConfiguration() {


### PR DESCRIPTION
All controls scaled to match the 60% screen panel. Cards are 160×140pt, diagrams 120×80pt, proper Canvas rendering with strokes and rounded corners.