### PR TITLE
fix: auto-detect on plug-in, implement toast, remember dropdown

### DIFF
--- a/Sources/Pane/App/AppDelegate.swift
+++ b/Sources/Pane/App/AppDelegate.swift
@@ -124,6 +124,15 @@ extension AppDelegate: DisplayMonitorDelegate {
 
             let modeLabel = "\(savedConfig.mode.displayName.lowercased()) \(savedConfig.extendPreset.displayName.lowercased())"
             Self.logger.info("Applied saved config: \(modeLabel)")
+
+            // Show toast
+            toastController?.show(
+                message: "\(name) — \(modeLabel) applied",
+                onChangeTapped: { [weak self] in
+                    self?.toastController?.dismiss()
+                    self?.showPrompt(displayID: id, uuid: uuid, name: name, resolution: resolution)
+                }
+            )
         } else {
             // Unknown display — show prompt
             currentDisplay = ConnectedDisplay(

--- a/Sources/Pane/Display/DisplayMonitor.swift
+++ b/Sources/Pane/Display/DisplayMonitor.swift
@@ -63,9 +63,14 @@ final class DisplayMonitor: @unchecked Sendable {
     // MARK: - Reconfiguration handler
 
     func handleReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
+        // Log all events for debugging
+        Self.logger.debug("Reconfiguration event: display=\(displayID) flags=\(flags.rawValue) add=\(flags.contains(.addFlag)) builtin=\(CGDisplayIsBuiltin(displayID)) mirror=\(CGDisplayIsInMirrorSet(displayID))")
+
         guard flags.contains(.addFlag) else { return }
         guard !CGDisplayIsBuiltin(displayID).boolValue else { return }
-        guard !CGDisplayIsInMirrorSet(displayID).boolValue else { return }
+
+        // Don't filter on mirror set here — macOS may briefly mirror during reconfiguration.
+        // The display might already be in a mirror set if macOS auto-mirrors on connect.
 
         let uuid = displayUUID(for: displayID)
         let name = displayName(for: displayID)

--- a/Sources/Pane/UI/ToastWindowController.swift
+++ b/Sources/Pane/UI/ToastWindowController.swift
@@ -3,37 +3,134 @@ import SwiftUI
 
 /// Ephemeral toast notification for known-display auto-apply events.
 ///
-/// Appears bottom-right of primary display, auto-dismisses after configurable duration.
-/// See pane-spec Section 8.
+/// Appears bottom-right of the built-in display, auto-dismisses after configurable duration.
 @MainActor
 final class ToastWindowController {
 
     private var panel: NSPanel?
     private var dismissTask: Task<Void, Never>?
 
-    /// Show a toast notification.
-    ///
-    /// - Parameters:
-    ///   - message: e.g. "LG UltraWide — extend left applied"
-    ///   - duration: seconds before auto-dismiss (default 4)
-    ///   - onChangeTapped: called when user taps the "change" link
     func show(
         message: String,
         duration: TimeInterval = 4,
         onChangeTapped: @escaping () -> Void
     ) {
-        // TODO: Phase 3 — Create borderless NSPanel:
-        //   - level = .floating
-        //   - Position bottom-right, 20pt inset
-        //   - Animate in: slide up 12pt + opacity 0→1 over 0.2s
-        //   - Schedule dismissal after `duration`
-        //   - Animate out: opacity 1→0 over 0.15s
+        dismiss()
+
+        let toastView = ToastView(message: message, onChangeTapped: {
+            onChangeTapped()
+        })
+
+        let hostingView = NSHostingView(rootView: toastView)
+        hostingView.setFrameSize(hostingView.fittingSize)
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: hostingView.fittingSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.contentView = hostingView
+        panel.isReleasedWhenClosed = false
+
+        // Position bottom-right of built-in screen, 20pt inset
+        let screen = builtInScreen() ?? NSScreen.main ?? NSScreen.screens.first
+        if let screenFrame = screen?.visibleFrame {
+            let panelSize = panel.frame.size
+            let x = screenFrame.maxX - panelSize.width - 20
+            let y = screenFrame.minY + 20
+            panel.setFrameOrigin(NSPoint(x: x, y: y - 12)) // start 12pt lower for slide-up
+        }
+
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        self.panel = panel
+
+        // Animate in: slide up 12pt + fade in
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+            var origin = panel.frame.origin
+            origin.y += 12
+            panel.animator().setFrameOrigin(origin)
+        }
+
+        // Schedule auto-dismiss
+        dismissTask = Task {
+            try? await Task.sleep(for: .seconds(duration))
+            guard !Task.isCancelled else { return }
+            animateOut()
+        }
     }
 
-    /// Dismiss the toast immediately.
     func dismiss() {
         dismissTask?.cancel()
         panel?.close()
         panel = nil
+    }
+
+    private func animateOut() {
+        guard let panel else { return }
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.15
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            self?.panel?.close()
+            self?.panel = nil
+        })
+    }
+
+    private func builtInScreen() -> NSScreen? {
+        NSScreen.screens.first { screen in
+            guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+                return false
+            }
+            return CGDisplayIsBuiltin(screenNumber) != 0
+        }
+    }
+}
+
+/// SwiftUI view for the toast notification content.
+struct ToastView: View {
+    let message: String
+    let onChangeTapped: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(.green)
+                .frame(width: 10, height: 10)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(message)
+                    .font(.system(size: 13, weight: .medium))
+                HStack(spacing: 4) {
+                    Text("from memory ·")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                    Button("change") {
+                        onChangeTapped()
+                    }
+                    .font(.system(size: 11))
+                    .buttonStyle(.link)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+        )
     }
 }

--- a/Sources/Pane/Views/PromptView.swift
+++ b/Sources/Pane/Views/PromptView.swift
@@ -71,11 +71,14 @@ struct PromptView: View {
 
             Spacer()
 
-            // Remember checkbox
-            Toggle("Remember for this display", isOn: $rememberDisplay)
-                .toggleStyle(.checkbox)
-                .font(.system(size: 15))
-                .padding(.bottom, 24)
+            // Remember preference
+            Picker("", selection: $rememberDisplay) {
+                Text("Remember for this display").tag(true)
+                Text("Prompt every time for this monitor").tag(false)
+            }
+            .labelsHidden()
+            .frame(width: 320)
+            .padding(.bottom, 24)
 
             // Action buttons
             HStack(spacing: 20) {


### PR DESCRIPTION
1. **Auto-detect**: Removed `CGDisplayIsInMirrorSet` guard — macOS auto-mirrors on connect, filtering the event. Added debug logging.
2. **Toast**: Full implementation — slide-up animation, auto-dismiss, material background, 'change' link.
3. **Dropdown**: Replaced checkbox with picker: 'Remember for this display' / 'Prompt every time for this monitor'.