### PR TITLE
feat: show display name instead of UUID in remembered displays

### DIFF
--- a/Sources/Pane/App/AppDelegate.swift
+++ b/Sources/Pane/App/AppDelegate.swift
@@ -95,7 +95,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID)
 
         if config.rememberThisDisplay {
-            configStore.save(config, for: uuid)
+            var savedConfig = config
+            savedConfig.displayName = name
+            configStore.save(savedConfig, for: uuid)
             Self.logger.notice("Saved config for \(name) [\(uuid)]")
         }
 

--- a/Sources/Pane/Display/DisplayConfiguration.swift
+++ b/Sources/Pane/Display/DisplayConfiguration.swift
@@ -23,6 +23,8 @@ struct DisplayConfiguration: Codable, Sendable {
     var extendPreset: ExtendPreset
     var mirrorTarget: MirrorTarget
     var rememberThisDisplay: Bool
+    /// Human-readable display name (e.g. "LG UltraWide"). Optional for backwards compat with older plists.
+    var displayName: String?
 }
 
 // MARK: - Display-friendly labels

--- a/Sources/Pane/UI/MenuBarController.swift
+++ b/Sources/Pane/UI/MenuBarController.swift
@@ -79,7 +79,8 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             submenu.addItem(empty)
         } else {
             for entry in entries {
-                let label = "\(entry.uuid.prefix(8))… · \(entry.config.mode.displayName) \(entry.config.extendPreset.displayName)"
+                let name = entry.config.displayName ?? "\(entry.uuid.prefix(8))…"
+                let label = "\(name) · \(entry.config.mode.displayName) \(entry.config.extendPreset.displayName)"
                 let item = NSMenuItem(title: label, action: nil, keyEquivalent: "")
                 item.isEnabled = false
                 submenu.addItem(item)

--- a/Sources/Pane/Views/SettingsView.swift
+++ b/Sources/Pane/Views/SettingsView.swift
@@ -70,7 +70,7 @@ struct SettingsView: View {
                     ForEach(entries, id: \.uuid) { entry in
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(entry.uuid.prefix(12) + "…")
+                                Text(entry.config.displayName ?? String(entry.uuid.prefix(12)) + "…")
                                     .font(.system(size: 13, weight: .medium))
                                 Text("\(entry.config.mode.displayName) · \(entry.config.extendPreset.displayName)")
                                     .font(.system(size: 11))


### PR DESCRIPTION
### Problem

Remembered displays show a truncated UUID (e.g. `84980A06-A4A…`) in both the Settings Displays tab and the menu bar submenu. This is not useful to users.

### Solution

- Add `displayName: String?` to `DisplayConfiguration` (optional for backwards compat with existing plists)
- Save the IOKit display name when persisting a config
- Show the display name in Settings and menu bar, falling back to UUID prefix for old entries without a name

### Note

Existing remembered displays will still show UUIDs until they're forgotten and re-saved. New saves will include the display name automatically.