### PR TITLE
feat: display name, size, resolution, remember UX rework

### DIFF
--- a/Sources/Pane/App/AppDelegate.swift
+++ b/Sources/Pane/App/AppDelegate.swift
@@ -94,12 +94,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ) {
         DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID)
 
-        if config.rememberThisDisplay {
-            var savedConfig = config
-            savedConfig.displayName = name
-            configStore.save(savedConfig, for: uuid)
-            Self.logger.notice("Saved config for \(name) [\(uuid)]")
-        }
+        // Always save the config so the display appears in Settings.
+        // rememberThisDisplay controls whether to auto-apply silently next time.
+        var savedConfig = config
+        savedConfig.displayName = name
+        let nativeW = CGDisplayPixelsWide(displayID)
+        let nativeH = CGDisplayPixelsHigh(displayID)
+        savedConfig.resolutionWidth = nativeW
+        savedConfig.resolutionHeight = nativeH
+        let physicalSize = CGDisplayScreenSize(displayID)
+        let diagonalInches = sqrt(physicalSize.width * physicalSize.width + physicalSize.height * physicalSize.height) / 25.4
+        savedConfig.screenSizeInches = Int(diagonalInches.rounded())
+        configStore.save(savedConfig, for: uuid)
+        Self.logger.notice("Saved config for \(name) [\(uuid)] (auto-apply: \(config.rememberThisDisplay))")
 
         currentDisplay = ConnectedDisplay(
             id: displayID, uuid: uuid, name: name, resolution: resolution, appliedConfig: config
@@ -129,8 +136,8 @@ extension AppDelegate: DisplayMonitorDelegate {
     ) {
         Self.logger.notice("Display connected: \(name) [\(uuid)]")
 
-        if let savedConfig = configStore.configuration(for: uuid) {
-            // Known display — apply silently
+        if let savedConfig = configStore.configuration(for: uuid), savedConfig.rememberThisDisplay {
+            // Known display with auto-apply — apply silently
             DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id)
             currentDisplay = ConnectedDisplay(
                 id: id, uuid: uuid, name: name, resolution: resolution, appliedConfig: savedConfig
@@ -158,7 +165,7 @@ extension AppDelegate: DisplayMonitorDelegate {
                 }
             }
         } else {
-            // Unknown display — show prompt
+            // Unknown display or known but not auto-apply — show prompt
             currentDisplay = ConnectedDisplay(
                 id: id, uuid: uuid, name: name, resolution: resolution, appliedConfig: nil
             )

--- a/Sources/Pane/Display/DisplayConfiguration.swift
+++ b/Sources/Pane/Display/DisplayConfiguration.swift
@@ -25,6 +25,12 @@ struct DisplayConfiguration: Codable, Sendable {
     var rememberThisDisplay: Bool
     /// Human-readable display name (e.g. "LG UltraWide"). Optional for backwards compat with older plists.
     var displayName: String?
+    /// Native resolution width. Optional for backwards compat.
+    var resolutionWidth: Int?
+    /// Native resolution height. Optional for backwards compat.
+    var resolutionHeight: Int?
+    /// Display diagonal size in inches (e.g. 27). Optional for backwards compat.
+    var screenSizeInches: Int?
 }
 
 // MARK: - Display-friendly labels

--- a/Sources/Pane/Display/DisplayMonitor.swift
+++ b/Sources/Pane/Display/DisplayMonitor.swift
@@ -1,7 +1,7 @@
+import AppKit
 import ColorSync
 import CoreGraphics
 import Foundation
-import IOKit
 import os
 
 /// Delegate protocol for display connection events.
@@ -104,45 +104,15 @@ final class DisplayMonitor: @unchecked Sendable {
         return cfString as String
     }
 
-    /// Returns the human-readable product name via IOKit.
+    /// Returns the human-readable product name via NSScreen.
     func displayName(for displayID: CGDirectDisplayID) -> String {
-        var serialPortIterator = io_iterator_t()
-        let matching = IOServiceMatching("IODisplayConnect")
-
-        let result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &serialPortIterator)
-        guard result == KERN_SUCCESS else {
-            Self.logger.warning("IOServiceGetMatchingServices failed for display \(displayID)")
-            return "External Display"
-        }
-        defer { IOObjectRelease(serialPortIterator) }
-
-        var service = IOIteratorNext(serialPortIterator)
-        while service != IO_OBJECT_NULL {
-            defer {
-                IOObjectRelease(service)
-                service = IOIteratorNext(serialPortIterator)
-            }
-
-            guard let info = IODisplayCreateInfoDictionary(service, IOOptionBits(kIODisplayOnlyPreferredName))?.takeRetainedValue() as? [String: Any] else {
-                continue
-            }
-
-            // Match by vendor and product ID
-            guard let vendorID = info[kDisplayVendorID] as? UInt32,
-                  let productID = info[kDisplayProductID] as? UInt32 else {
-                continue
-            }
-
-            if vendorID == CGDisplayVendorNumber(displayID),
-               productID == CGDisplayModelNumber(displayID) {
-                if let names = info[kDisplayProductName] as? [String: String],
-                   let name = names.values.first {
-                    return name
-                }
+        for screen in NSScreen.screens {
+            let screenID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+            if screenID == displayID {
+                return screen.localizedName
             }
         }
-
-        Self.logger.notice("No IOKit product name found for display \(displayID), using fallback")
+        Self.logger.notice("No NSScreen match for display \(displayID), using fallback")
         return "External Display"
     }
 }

--- a/Sources/Pane/UI/MenuBarController.swift
+++ b/Sources/Pane/UI/MenuBarController.swift
@@ -79,8 +79,11 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             submenu.addItem(empty)
         } else {
             for entry in entries {
-                let name = entry.config.displayName ?? "\(entry.uuid.prefix(8))…"
-                let label = "\(name) · \(entry.config.mode.displayName) \(entry.config.extendPreset.displayName)"
+                var parts = [entry.config.displayName ?? "\(entry.uuid.prefix(8))…"]
+                if let size = entry.config.screenSizeInches {
+                    parts.append("\(size)″")
+                }
+                let label = "\(parts.joined(separator: " ")) · \(entry.config.mode.displayName) \(entry.config.extendPreset.displayName)"
                 let item = NSMenuItem(title: label, action: nil, keyEquivalent: "")
                 item.isEnabled = false
                 submenu.addItem(item)

--- a/Sources/Pane/Views/SettingsView.swift
+++ b/Sources/Pane/Views/SettingsView.swift
@@ -98,11 +98,26 @@ struct SettingsView: View {
                     ForEach(entries, id: \.uuid) { entry in
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(entry.config.displayName ?? String(entry.uuid.prefix(12)) + "…")
+                                let displayLabel: String = {
+                                    var parts = [entry.config.displayName ?? String(entry.uuid.prefix(12)) + "…"]
+                                    if let size = entry.config.screenSizeInches {
+                                        parts.append("\(size)″")
+                                    }
+                                    if let w = entry.config.resolutionWidth, let h = entry.config.resolutionHeight {
+                                        parts.append("(\(w) × \(h))")
+                                    }
+                                    return parts.joined(separator: " ")
+                                }()
+                                Text(displayLabel)
                                     .font(.system(size: 13, weight: .medium))
-                                Text("\(entry.config.mode.displayName) · \(entry.config.extendPreset.displayName)")
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 4) {
+                                    let preset = entry.config.mode == .mirror
+                                        ? entry.config.mirrorTarget.displayName
+                                        : entry.config.extendPreset.displayName
+                                    Text("\(entry.config.mode.displayName) · \(preset)\(entry.config.rememberThisDisplay ? "" : " · Prompt")")
+                                }
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
                             }
 
                             Spacer()


### PR DESCRIPTION
Cherry-picked from test/all-fixes (e4cd1b6). 

## Changes
- Switch display name lookup from IOKit IODisplayConnect to NSScreen.localizedName (works on macOS 15+)
- Store display name, native resolution, and physical screen size (inches) in DisplayConfiguration
- Settings Displays tab now shows rich descriptors: e.g. DELL U2723QE 27″ (3840 × 2160)
- rememberThisDisplay now controls auto-apply vs always-prompt (config always saved on Apply)
- Menu bar remembered displays submenu shows name + size