### PR TITLE
Detect already-connected displays at launch

### DIFF
--- a/Sources/Pane/App/AppDelegate.swift
+++ b/Sources/Pane/App/AppDelegate.swift
@@ -55,6 +55,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         monitor.startMonitoring()
         displayMonitor = monitor
 
+        // Scan for displays already connected at launch
+        scanForConnectedDisplays()
+
         Self.logger.notice("Pane started")
     }
 
@@ -122,6 +125,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             resolution: display.resolution
         )
     }
+
+    // MARK: - Startup scan
+
+    /// Finds external displays already connected when the app launches.
+    private func scanForConnectedDisplays() {
+        guard let monitor = displayMonitor else { return }
+
+        var displayCount: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &displayCount) == .success,
+              displayCount > 0
+        else {
+            Self.logger.notice("No online displays found at launch")
+            return
+        }
+
+        var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
+        guard CGGetOnlineDisplayList(displayCount, &displayIDs, &displayCount) == .success else {
+            Self.logger.error("Failed to enumerate online displays")
+            return
+        }
+
+        for id in displayIDs where CGDisplayIsBuiltin(id) == 0 {
+            let uuid = monitor.displayUUID(for: id)
+            let name = monitor.displayName(for: id)
+            let bounds = CGDisplayBounds(id)
+            Self.logger.notice(
+                "Found external display at launch: \(name) [\(uuid)]"
+            )
+            displayDidConnect(
+                id: id,
+                uuid: uuid,
+                name: name,
+                resolution: bounds.size
+            )
+        }
+    }
 }
 
 // MARK: - DisplayMonitorDelegate
@@ -180,5 +219,13 @@ extension AppDelegate: DisplayMonitorDelegate {
             menuBarController?.updateCurrentDisplay(currentDisplay)
             showPrompt(displayID: id, uuid: uuid, name: name, resolution: resolution)
         }
+    }
+
+    func displayDidDisconnect(id: CGDirectDisplayID) {
+        guard currentDisplay?.id == id else { return }
+        let name = currentDisplay?.name ?? "unknown"
+        Self.logger.notice("Display disconnected: \(name) (ID \(id))")
+        currentDisplay = nil
+        menuBarController?.updateCurrentDisplay(nil)
     }
 }

--- a/Sources/Pane/Display/DisplayMonitor.swift
+++ b/Sources/Pane/Display/DisplayMonitor.swift
@@ -13,6 +13,7 @@ protocol DisplayMonitorDelegate: AnyObject {
         name: String,
         resolution: CGSize
     )
+    func displayDidDisconnect(id: CGDirectDisplayID)
 }
 
 /// Registers for CGDisplay reconfiguration events and dispatches to delegate.
@@ -67,8 +68,17 @@ final class DisplayMonitor: @unchecked Sendable {
             "Reconfiguration event: display=\(displayID) flags=\(flags.rawValue) add=\(flags.contains(.addFlag)) builtin=\(CGDisplayIsBuiltin(displayID)) mirror=\(CGDisplayIsInMirrorSet(displayID))"
         )
 
-        guard flags.contains(.addFlag) else { return }
         guard !CGDisplayIsBuiltin(displayID).boolValue else { return }
+
+        if flags.contains(.removeFlag) {
+            Self.logger.notice("External display disconnected: \(displayID)")
+            Task { @MainActor in
+                self.delegate?.displayDidDisconnect(id: displayID)
+            }
+            return
+        }
+
+        guard flags.contains(.addFlag) else { return }
 
         // Don't filter on mirror set here — macOS may briefly mirror during reconfiguration.
         // The display might already be in a mirror set if macOS auto-mirrors on connect.


### PR DESCRIPTION
Scans for external displays on startup via `CGGetOnlineDisplayList` so the app works immediately without requiring an unplug/replug cycle. Also tracks disconnect events to clear stale state.

**Changes:**
- `AppDelegate`: adds `scanForConnectedDisplays()` called at end of `applicationDidFinishLaunching`
- `DisplayMonitor`: handles `.removeFlag` for disconnect detection
- `DisplayMonitorDelegate`: adds `displayDidDisconnect(id:)`

Fixes #12