### PR TITLE
chore: secure appcast dispatch with environment approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [archive, publish]
     runs-on: ubuntu-latest
+    environment: website-deploy
 
     steps:
       - name: Dispatch to website

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: macos-15
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      ed_signature: ${{ steps.sparkle.outputs.ed_signature }}
+      length: ${{ steps.sparkle.outputs.length }}
+      build_version: ${{ steps.appcast.outputs.build_version }}
+      pub_date: ${{ steps.appcast.outputs.pub_date }}
 
     steps:
       - uses: actions/checkout@v4
@@ -117,6 +123,7 @@ jobs:
           echo "length=${LENGTH}" >> "$GITHUB_OUTPUT"
 
       - name: Generate appcast snippet
+        id: appcast
         if: steps.sparkle.outputs.ed_signature
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -142,6 +149,8 @@ jobs:
           echo "────── Appcast <item> ──────"
           cat build/appcast-snippet.xml
           echo "────────────────────────────"
+          echo "build_version=${BUILD}" >> "$GITHUB_OUTPUT"
+          echo "pub_date=${PUBDATE}" >> "$GITHUB_OUTPUT"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
@@ -202,3 +211,41 @@ jobs:
           body: ${{ steps.body.outputs.body }}
           files: Snap-${{ steps.version.outputs.version }}.dmg
           generate_release_notes: true
+
+  notify-website:
+    name: Update website appcast
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [archive, publish]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch to website
+        env:
+          TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          VERSION: ${{ needs.archive.outputs.version }}
+          BUILD_VERSION: ${{ needs.archive.outputs.build_version }}
+          ED_SIGNATURE: ${{ needs.archive.outputs.ed_signature }}
+          LENGTH: ${{ needs.archive.outputs.length }}
+          PUB_DATE: ${{ needs.archive.outputs.pub_date }}
+        run: |
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${TOKEN}" \
+            https://api.github.com/repos/SteamedHamsAU/steamedhams-website/dispatches \
+            -d "$(jq -n \
+              --arg v "$VERSION" \
+              --arg bv "$BUILD_VERSION" \
+              --arg sig "$ED_SIGNATURE" \
+              --arg len "$LENGTH" \
+              --arg pd "$PUB_DATE" \
+              '{
+                event_type: "snap-release",
+                client_payload: {
+                  version: $v,
+                  build_version: $bv,
+                  ed_signature: $sig,
+                  length: $len,
+                  pub_date: $pd
+                }
+              }'
+            )"


### PR DESCRIPTION
## What

Adds the `website-deploy` environment gate to the `notify-website` job in the release workflow. This is a one-line change — the environment and protections are already configured on the repo.

## Security setup (already done)

- ✅ **`website-deploy` environment** — requires @lmoloney approval before the dispatch job runs
- ✅ **Tag ruleset** — only repo admins can create/delete `v*` tags
- ✅ **Branch protection on `main`** — requires PR review (was already in place)
- ✅ **Environment deployment policy** — only `v*` tags can trigger the environment

## One manual step remaining

Create and store the `WEBSITE_DISPATCH_TOKEN` secret:

1. Go to https://github.com/settings/personal-access-tokens/new
2. **Name:** `snap-website-dispatch`
3. **Expiration:** 90 days
4. **Resource owner:** `SteamedHamsAU`
5. **Repository access:** Only select repositories → `steamedhams-website`
6. **Permissions → Repository:** `Contents: Read and write`
7. Generate the token, then run:

```bash
gh secret set WEBSITE_DISPATCH_TOKEN --repo SteamedHamsAU/snap
```

Paste the token when prompted. Done — the full pipeline is live.

## How it works end-to-end

1. Push a `v*` tag → release workflow builds DMG, signs with Sparkle
2. `publish` job creates GitHub Release
3. `notify-website` job **pauses for your approval** in the GitHub UI
4. You click Approve → dispatches to `steamedhams-website` with version metadata
5. Website workflow inserts `<item>` into `appcast.xml`, commits, and Cloudflare deploys