### PR TITLE
fix: scope Option-click debug toggle to tab-switch gesture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Build (Debug)
         run: |
+          set -o pipefail
           xcodebuild build \
             -scheme Snap \
             -configuration Debug \
@@ -45,6 +46,7 @@ jobs:
 
       - name: Build (Release)
         run: |
+          set -o pipefail
           xcodebuild build \
             -scheme Snap \
             -configuration Release \
@@ -56,10 +58,13 @@ jobs:
 
       - name: Test
         run: |
+          set -o pipefail
           xcodebuild test \
             -scheme Snap \
-            -destination 'platform=macOS' \
+            -destination 'platform=macOS,arch=arm64' \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            GENERATE_INFOPLIST_FILE=YES \
             | xcbeautify
+        timeout-minutes: 10

--- a/.swiftformat
+++ b/.swiftformat
@@ -3,5 +3,6 @@
 --allman false
 --wraparguments before-first
 --maxwidth 120
+--commas inline
 --disable redundantSelf
 --modifierorder nonisolated,override,private,public,internal,fileprivate,open,static,class,final,lazy,required,optional,convenience,dynamic,weak,unowned,mutating,nonmutating

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -13,6 +13,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsController: SettingsWindowController?
     private let configStore = DisplayConfigStore()
     private var currentDisplay: ConnectedDisplay?
+    private var pendingToastTask: Task<Void, Never>?
 
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -67,6 +68,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_: Notification) {
         displayMonitor?.stopMonitoring()
+        promptController?.dismiss()
+        toastController?.dismiss()
+        pendingToastTask?.cancel()
     }
 
     // MARK: - First-run launch at login
@@ -133,9 +137,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         name: String,
         resolution: CGSize
     ) {
+        // Guard against stale prompts — the display may have gone offline
+        // (e.g. phantom during sleep/wake) since the prompt was shown.
+        guard isDisplayOnline(displayID) else {
+            Self.logger.warning("Display \(displayID) [\(uuid)] is offline — skipping apply and save")
+            return
+        }
+        if let monitor = displayMonitor {
+            let currentUUID = monitor.displayUUID(for: displayID)
+            guard currentUUID == uuid else {
+                Self.logger.warning(
+                    "Display \(displayID) UUID changed (\(uuid) → \(currentUUID)) — skipping apply and save"
+                )
+                return
+            }
+        }
+
         DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID)
 
-        // Always save the config so the display appears in Settings.
+        // Save the config so the display appears in Settings.
         // rememberThisDisplay controls whether to auto-apply silently next time.
         var savedConfig = config
         savedConfig.displayName = name
@@ -148,6 +168,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             physicalSize.width * physicalSize.width + physicalSize.height * physicalSize.height
         ) / 25.4
         savedConfig.screenSizeInches = Int(diagonalInches.rounded())
+        savedConfig.lastConnected = Date()
         configStore.save(savedConfig, for: uuid)
         Self.logger.notice("Saved config for \(name) [\(uuid)] (auto-apply: \(config.rememberThisDisplay))")
 
@@ -155,6 +176,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             id: displayID, uuid: uuid, name: name, resolution: resolution, appliedConfig: config
         )
         menuBarController?.updateCurrentDisplay(currentDisplay)
+    }
+
+    /// Checks whether the given display ID is in the current online display list.
+    private func isDisplayOnline(_ displayID: CGDirectDisplayID) -> Bool {
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success, count > 0 else {
+            return false
+        }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else {
+            return false
+        }
+        return ids.contains(displayID)
     }
 
     private func retriggerPrompt() {
@@ -215,11 +249,20 @@ extension AppDelegate: DisplayMonitorDelegate {
     ) {
         Self.logger.notice("Display connected: \(name) [\(uuid)]")
 
+        // Dismiss any stale prompt (e.g. from a phantom display during sleep/wake)
+        promptController?.dismiss()
+
         if let savedConfig = configStore.configuration(for: uuid), savedConfig.rememberThisDisplay {
             // Known display with auto-apply — apply silently
             DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id)
+
+            // Update lastConnected timestamp
+            var updatedConfig = savedConfig
+            updatedConfig.lastConnected = Date()
+            configStore.save(updatedConfig, for: uuid)
+
             currentDisplay = ConnectedDisplay(
-                id: id, uuid: uuid, name: name, resolution: resolution, appliedConfig: savedConfig
+                id: id, uuid: uuid, name: name, resolution: resolution, appliedConfig: updatedConfig
             )
             menuBarController?.updateCurrentDisplay(currentDisplay)
 
@@ -240,8 +283,10 @@ extension AppDelegate: DisplayMonitorDelegate {
             let showToast = UserDefaults.standard.object(forKey: "showToastOnKnownDisplay") as? Bool ?? true
             if showToast {
                 let toastMessage = "\(name) — \(modeLabel) applied"
-                Task { @MainActor [weak self] in
+                pendingToastTask?.cancel()
+                pendingToastTask = Task { @MainActor [weak self] in
                     try? await Task.sleep(for: .seconds(1.5))
+                    guard !Task.isCancelled else { return }
                     Self.logger.notice("Showing toast: \(toastMessage)")
                     self?.toastController?.show(
                         message: toastMessage,
@@ -263,6 +308,9 @@ extension AppDelegate: DisplayMonitorDelegate {
     }
 
     func displayDidDisconnect(id: CGDirectDisplayID) {
+        // Dismiss any open prompt — it's stale if the display is gone
+        promptController?.dismiss()
+
         guard currentDisplay?.id == id else { return }
         let name = currentDisplay?.name ?? "unknown"
         Self.logger.notice("Display disconnected: \(name) (ID \(id))")

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -27,6 +27,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
 
     func applicationDidFinishLaunching(_: Notification) {
+        // Skip UI and hardware setup when running as a unit test host
+        guard !isRunningTests else {
+            Self.logger.notice("Snap launched as test host — skipping UI setup")
+            return
+        }
+
         // Menu bar
         let menuBar = MenuBarController(configStore: configStore)
         menuBar.onRetriggerPrompt = { [weak self] in
@@ -189,6 +195,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return false
         }
         return ids.contains(displayID)
+    }
+
+    /// Detects whether the app was launched as a unit test host.
+    private var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestBundlePath"] != nil
     }
 
     private func retriggerPrompt() {

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Persists display configurations keyed by display UUID.
 ///
@@ -8,15 +9,27 @@ final class DisplayConfigStore {
     private var configurations: [String: DisplayConfiguration] = [:]
     private let fileURL: URL
 
-    init() {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
+        category: "DisplayConfigStore"
+    )
+
+    convenience init() {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let snapDir = appSupport.appendingPathComponent("Snap", isDirectory: true)
-        fileURL = snapDir.appendingPathComponent("displays.plist")
+        self.init(fileURL: snapDir.appendingPathComponent("displays.plist"))
+    }
 
-        // Ensure directory exists
-        try? FileManager.default.createDirectory(at: snapDir, withIntermediateDirectories: true)
+    init(fileURL: URL) {
+        self.fileURL = fileURL
 
-        // Load existing configurations
+        let parentDir = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+        } catch {
+            Self.logger.error("Failed to create config directory: \(error)")
+        }
+
         load()
     }
 
@@ -48,15 +61,35 @@ final class DisplayConfigStore {
     // MARK: - Private
 
     private func load() {
-        guard let data = try? Data(contentsOf: fileURL) else { return }
-        let decoder = PropertyListDecoder()
-        configurations = (try? decoder.decode([String: DisplayConfiguration].self, from: data)) ?? [:]
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+            // No file yet — first launch, not an error
+            return
+        } catch {
+            Self.logger.error("Failed to read config file: \(error)")
+            return
+        }
+
+        do {
+            configurations = try PropertyListDecoder().decode(
+                [String: DisplayConfiguration].self,
+                from: data
+            )
+        } catch {
+            Self.logger.error("Failed to decode config file: \(error)")
+        }
     }
 
     private func persist() {
-        let encoder = PropertyListEncoder()
-        encoder.outputFormat = .xml
-        guard let data = try? encoder.encode(configurations) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        do {
+            let encoder = PropertyListEncoder()
+            encoder.outputFormat = .xml
+            let data = try encoder.encode(configurations)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            Self.logger.error("Failed to persist config file: \(error)")
+        }
     }
 }

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -64,7 +64,9 @@ final class DisplayConfigStore {
         let data: Data
         do {
             data = try Data(contentsOf: fileURL)
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+        } catch let error as NSError
+            where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError
+        {
             // No file yet — first launch, not an error
             return
         } catch {

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -15,7 +15,19 @@ final class DisplayConfigStore {
     )
 
     convenience init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport: URL
+        do {
+            appSupport = try FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        } catch {
+            Self.logger.error("Failed to resolve Application Support directory: \(error)")
+            appSupport = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        }
         let snapDir = appSupport.appendingPathComponent("Snap", isDirectory: true)
         self.init(fileURL: snapDir.appendingPathComponent("displays.plist"))
     }

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -64,12 +64,12 @@ final class DisplayConfigStore {
         let data: Data
         do {
             data = try Data(contentsOf: fileURL)
-        } catch let error as NSError
-            where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError
-        {
-            // No file yet — first launch, not an error
-            return
         } catch {
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileReadNoSuchFileError {
+                // No file yet — first launch, not an error
+                return
+            }
             Self.logger.error("Failed to read config file: \(error)")
             return
         }

--- a/Sources/Snap/Display/DisplayConfiguration.swift
+++ b/Sources/Snap/Display/DisplayConfiguration.swift
@@ -30,6 +30,8 @@ struct DisplayConfiguration: Codable {
     var resolutionHeight: Int?
     /// Display diagonal size in inches (e.g. 27). Optional for backwards compat.
     var screenSizeInches: Int?
+    /// Timestamp of the most recent connection event. Optional for backwards compat.
+    var lastConnected: Date?
 }
 
 // MARK: - Display-friendly labels

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -10,7 +10,7 @@ import os
 protocol DisplayTransacting {
     func beginConfiguration() -> CGDisplayConfigRef?
     func configureOrigin(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32)
-    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID)
+    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, primary: CGDirectDisplayID)
     func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool
     func displayBounds(_ display: CGDirectDisplayID) -> CGRect
 }
@@ -31,8 +31,8 @@ struct SystemDisplayTransactor: DisplayTransacting {
         CGConfigureDisplayOrigin(configRef, display, x, y)
     }
 
-    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID) {
-        CGConfigureDisplayMirrorOfDisplay(configRef, display, master)
+    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, primary: CGDirectDisplayID) {
+        CGConfigureDisplayMirrorOfDisplay(configRef, display, primary)
     }
 
     func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool {
@@ -75,7 +75,7 @@ enum DisplayConfigurator {
         switch config.mode {
         case .extend:
             // Always unmirror first (handles mirror → extend transition)
-            transactor.configureMirror(cfg, display: externalID, master: kCGNullDirectDisplay)
+            transactor.configureMirror(cfg, display: externalID, primary: kCGNullDirectDisplay)
 
             let internalBounds = transactor.displayBounds(primaryID)
             let externalBounds = transactor.displayBounds(externalID)
@@ -103,9 +103,9 @@ enum DisplayConfigurator {
         case .mirror:
             switch config.mirrorTarget {
             case .macBook:
-                transactor.configureMirror(cfg, display: externalID, master: primaryID)
+                transactor.configureMirror(cfg, display: externalID, primary: primaryID)
             case .external:
-                transactor.configureMirror(cfg, display: primaryID, master: externalID)
+                transactor.configureMirror(cfg, display: primaryID, primary: externalID)
             }
             logger.info("Applying mirror target: \(config.mirrorTarget.rawValue)")
         }

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -2,6 +2,50 @@ import CoreGraphics
 import Foundation
 import os
 
+// MARK: - DisplayTransacting
+
+/// Abstracts CGDisplay configuration calls so `DisplayConfigurator` can be tested
+/// without hitting real hardware.
+@MainActor
+protocol DisplayTransacting {
+    func beginConfiguration() -> CGDisplayConfigRef?
+    func configureOrigin(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32)
+    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID)
+    func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool
+    func displayBounds(_ display: CGDirectDisplayID) -> CGRect
+}
+
+// MARK: - SystemDisplayTransactor
+
+/// Production implementation that forwards to the real CGDisplay C API.
+@MainActor
+struct SystemDisplayTransactor: DisplayTransacting {
+    func beginConfiguration() -> CGDisplayConfigRef? {
+        var configRef: CGDisplayConfigRef?
+        let status = CGBeginDisplayConfiguration(&configRef)
+        guard status == .success else { return nil }
+        return configRef
+    }
+
+    func configureOrigin(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32) {
+        CGConfigureDisplayOrigin(configRef, display, x, y)
+    }
+
+    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID) {
+        CGConfigureDisplayMirrorOfDisplay(configRef, display, master)
+    }
+
+    func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool {
+        CGCompleteDisplayConfiguration(configRef, .permanently) == .success
+    }
+
+    func displayBounds(_ display: CGDirectDisplayID) -> CGRect {
+        CGDisplayBounds(display)
+    }
+}
+
+// MARK: - DisplayConfigurator
+
 /// Applies display configurations using CGDisplay APIs.
 ///
 /// All methods must be called from `@MainActor` (CGDisplay APIs are synchronous
@@ -15,26 +59,26 @@ enum DisplayConfigurator {
 
     /// Apply the given configuration to the external display.
     ///
-    /// Wraps all changes in a `CGBeginDisplayConfiguration` / `CGCompleteDisplayConfiguration` transaction.
+    /// Wraps all changes in a `beginConfiguration` / `completeConfiguration` transaction
+    /// driven by the provided `transactor`. The default uses real CGDisplay APIs.
     static func apply(
         _ config: DisplayConfiguration,
         primaryID: CGDirectDisplayID,
-        externalID: CGDirectDisplayID
+        externalID: CGDirectDisplayID,
+        transactor: DisplayTransacting = SystemDisplayTransactor()
     ) {
-        var configRef: CGDisplayConfigRef?
-        let beginStatus = CGBeginDisplayConfiguration(&configRef)
-        guard beginStatus == .success, let cfg = configRef else {
-            logger.error("CGBeginDisplayConfiguration failed: \(beginStatus.rawValue)")
+        guard let cfg = transactor.beginConfiguration() else {
+            logger.error("beginConfiguration failed")
             return
         }
 
         switch config.mode {
         case .extend:
             // Always unmirror first (handles mirror → extend transition)
-            CGConfigureDisplayMirrorOfDisplay(cfg, externalID, kCGNullDirectDisplay)
+            transactor.configureMirror(cfg, display: externalID, master: kCGNullDirectDisplay)
 
-            let internalBounds = CGDisplayBounds(primaryID)
-            let externalBounds = CGDisplayBounds(externalID)
+            let internalBounds = transactor.displayBounds(primaryID)
+            let externalBounds = transactor.displayBounds(externalID)
             let origin = switch config.extendPreset {
             case .externalRight:
                 CGPoint(
@@ -53,24 +97,23 @@ enum DisplayConfigurator {
                 )
             }
 
-            CGConfigureDisplayOrigin(cfg, externalID, Int32(origin.x), Int32(origin.y))
+            transactor.configureOrigin(cfg, display: externalID, x: Int32(origin.x), y: Int32(origin.y))
             logger.info("Applying extend preset: \(config.extendPreset.rawValue)")
 
         case .mirror:
             switch config.mirrorTarget {
             case .macBook:
-                CGConfigureDisplayMirrorOfDisplay(cfg, externalID, primaryID)
+                transactor.configureMirror(cfg, display: externalID, master: primaryID)
             case .external:
-                CGConfigureDisplayMirrorOfDisplay(cfg, primaryID, externalID)
+                transactor.configureMirror(cfg, display: primaryID, master: externalID)
             }
             logger.info("Applying mirror target: \(config.mirrorTarget.rawValue)")
         }
 
-        let completeStatus = CGCompleteDisplayConfiguration(cfg, .permanently)
-        if completeStatus == .success {
+        if transactor.completeConfiguration(cfg) {
             logger.info("Display configuration applied successfully")
         } else {
-            logger.error("CGCompleteDisplayConfiguration failed: \(completeStatus.rawValue)")
+            logger.error("completeConfiguration failed")
         }
     }
 }

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -20,6 +20,10 @@ protocol DisplayMonitorDelegate: AnyObject {
 ///
 /// The CGDisplay callback arrives on an arbitrary thread — this class dispatches
 /// all delegate calls to `@MainActor`.
+///
+/// Marked `@unchecked Sendable` because the C callback bridge requires passing
+/// `self` as an opaque pointer across thread boundaries. Thread safety is
+/// maintained by dispatching all mutable state access to `@MainActor` via Task.
 final class DisplayMonitor: @unchecked Sendable {
     @MainActor weak var delegate: DisplayMonitorDelegate?
 
@@ -27,6 +31,18 @@ final class DisplayMonitor: @unchecked Sendable {
         subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
         category: "DisplayMonitor"
     )
+
+    /// Tracks pending debounce tasks per display ID so rapid events are coalesced.
+    @MainActor private var pendingEvents: [CGDirectDisplayID: Task<Void, Never>] = [:]
+
+    /// How long to wait for additional events before dispatching.
+    private let debounceInterval: Duration
+
+    /// Returns whether a display ID is the built-in panel. Injectable for testing.
+    private let isBuiltIn: @Sendable (CGDirectDisplayID) -> Bool
+
+    /// Returns whether a display ID is currently online. Injectable for testing.
+    private let isOnline: @Sendable (CGDirectDisplayID) -> Bool
 
     /// The C callback for `CGDisplayRegisterReconfigurationCallback`.
     /// Bridges to the Swift instance via an `Unmanaged` pointer in `userInfo`.
@@ -36,7 +52,25 @@ final class DisplayMonitor: @unchecked Sendable {
         monitor.handleReconfiguration(displayID: displayID, flags: flags)
     }
 
-    init() {}
+    init(
+        debounceInterval: Duration = .milliseconds(500),
+        isBuiltIn: @escaping @Sendable (CGDirectDisplayID) -> Bool = { CGDisplayIsBuiltin($0) != 0 },
+        isOnline: @escaping @Sendable (CGDirectDisplayID) -> Bool = { displayID in
+            var count: UInt32 = 0
+            guard CGGetOnlineDisplayList(0, nil, &count) == .success, count > 0 else {
+                return false
+            }
+            var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+            guard CGGetOnlineDisplayList(count, &ids, &count) == .success else {
+                return false
+            }
+            return ids.contains(displayID)
+        }
+    ) {
+        self.debounceInterval = debounceInterval
+        self.isBuiltIn = isBuiltIn
+        self.isOnline = isOnline
+    }
 
     // MARK: - Monitoring lifecycle
 
@@ -58,6 +92,11 @@ final class DisplayMonitor: @unchecked Sendable {
         Self.logger.notice("Display monitoring stopped")
     }
 
+    deinit {
+        let pointer = Unmanaged.passUnretained(self).toOpaque()
+        CGDisplayRemoveReconfigurationCallback(Self.reconfigurationCallback, pointer)
+    }
+
     // MARK: - Reconfiguration handler
 
     func handleReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
@@ -68,12 +107,12 @@ final class DisplayMonitor: @unchecked Sendable {
             "Reconfiguration event: display=\(displayID) flags=\(flags.rawValue) add=\(flags.contains(.addFlag)) builtin=\(CGDisplayIsBuiltin(displayID)) mirror=\(CGDisplayIsInMirrorSet(displayID))"
         )
 
-        guard !CGDisplayIsBuiltin(displayID).boolValue else { return }
+        guard !isBuiltIn(displayID) else { return }
 
         if flags.contains(.removeFlag) {
             Self.logger.notice("External display disconnected: \(displayID)")
-            Task { @MainActor in
-                self.delegate?.displayDidDisconnect(id: displayID)
+            dispatchDebounced(displayID: displayID) { monitor in
+                monitor.delegate?.displayDidDisconnect(id: displayID)
             }
             return
         }
@@ -83,22 +122,63 @@ final class DisplayMonitor: @unchecked Sendable {
         // Don't filter on mirror set here — macOS may briefly mirror during reconfiguration.
         // The display might already be in a mirror set if macOS auto-mirrors on connect.
 
-        let uuid = displayUUID(for: displayID)
+        let capturedUUID = displayUUID(for: displayID)
         let bounds = CGDisplayBounds(displayID)
         let resolution = bounds.size
 
         Self.logger.notice(
-            "External display connected: [\(uuid)] \(Int(resolution.width))×\(Int(resolution.height))"
+            "External display connected: [\(capturedUUID)] \(Int(resolution.width))×\(Int(resolution.height))"
         )
 
-        Task { @MainActor in
-            let name = self.displayName(for: displayID)
-            self.delegate?.displayDidConnect(
+        let isOnline = self.isOnline
+        dispatchDebounced(displayID: displayID) { monitor in
+            // Post-debounce validation: verify the display is still present and
+            // hasn't been replaced by a different physical display reusing the ID.
+            guard isOnline(displayID) else {
+                Self.logger.notice(
+                    "Display \(displayID) went offline during debounce — dropping connect event"
+                )
+                return
+            }
+            let currentUUID = monitor.displayUUID(for: displayID)
+            guard currentUUID == capturedUUID else {
+                Self.logger.notice(
+                    "Display \(displayID) UUID changed during debounce (\(capturedUUID) → \(currentUUID)) — dropping"
+                )
+                return
+            }
+
+            // Re-read metadata post-debounce — values may have settled
+            let name = monitor.displayName(for: displayID)
+            let settledBounds = CGDisplayBounds(displayID)
+            monitor.delegate?.displayDidConnect(
                 id: displayID,
-                uuid: uuid,
+                uuid: currentUUID,
                 name: name,
-                resolution: resolution
+                resolution: settledBounds.size
             )
+        }
+    }
+
+    /// Debounces rapid events for the same display ID.
+    ///
+    /// macOS can fire multiple reconfiguration callbacks for a single physical
+    /// plug event. This coalesces them so only the last event within the
+    /// debounce window is dispatched to the delegate.
+    private func dispatchDebounced(
+        displayID: CGDirectDisplayID,
+        action: @escaping @MainActor (DisplayMonitor) -> Void
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.pendingEvents[displayID]?.cancel()
+            self.pendingEvents[displayID] = Task { @MainActor [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: self.debounceInterval)
+                guard !Task.isCancelled else { return }
+                self.pendingEvents.removeValue(forKey: displayID)
+                action(self)
+            }
         }
     }
 

--- a/Sources/Snap/Display/PresetDefaults.swift
+++ b/Sources/Snap/Display/PresetDefaults.swift
@@ -4,6 +4,9 @@ import Foundation
 /// so the prompt can pre-select them on next open.
 ///
 /// See snap-spec Section 3 — Last-used preset.
+///
+/// Marked `@unchecked Sendable` because `UserDefaults` is thread-safe and
+/// the `defaults` instance is immutable after init.
 struct PresetDefaults: @unchecked Sendable {
     // MARK: - Keys
 

--- a/Sources/Snap/UI/PromptWindowController.swift
+++ b/Sources/Snap/UI/PromptWindowController.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// Uses `NSPanel` with `nonactivatingPanel` style so it appears without
 /// stealing focus from the current app.
 @MainActor
-final class PromptWindowController {
+final class PromptWindowController: NSObject, NSWindowDelegate {
     private var panel: NSPanel?
 
     /// Show the prompt for a newly connected display.
@@ -54,6 +54,7 @@ final class PromptWindowController {
         panel.titleVisibility = .hidden
         panel.contentView = hostingView
         panel.isReleasedWhenClosed = false
+        panel.delegate = self
 
         // Centre on the built-in display (MacBook screen)
         let x = screenFrame.midX - panelWidth / 2
@@ -76,6 +77,12 @@ final class PromptWindowController {
             let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
             return screenNumber == displayID
         }
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_: Notification) {
+        panel = nil
     }
 
     /// Find the built-in MacBook display.

--- a/Sources/Snap/UI/SettingsWindowController.swift
+++ b/Sources/Snap/UI/SettingsWindowController.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// Controls the settings window opened from the menu bar.
 @MainActor
-final class SettingsWindowController {
+final class SettingsWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private let configStore: DisplayConfigStore
     private let updaterController: SPUStandardUpdaterController
@@ -12,6 +12,7 @@ final class SettingsWindowController {
     init(configStore: DisplayConfigStore, updaterController: SPUStandardUpdaterController) {
         self.configStore = configStore
         self.updaterController = updaterController
+        super.init()
     }
 
     func show() {
@@ -39,8 +40,15 @@ final class SettingsWindowController {
         window.contentView = hostingView
         window.center()
         window.isReleasedWhenClosed = false
+        window.delegate = self
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         self.window = window
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_: Notification) {
+        window = nil
     }
 }

--- a/Sources/Snap/UI/ToastWindowController.swift
+++ b/Sources/Snap/UI/ToastWindowController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import os
 import UserNotifications
 
 /// Shows native macOS notifications for known-display auto-apply events.
@@ -7,6 +8,11 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
     private var onChangeTapped: (() -> Void)?
     private static let categoryID = "DISPLAY_APPLIED"
     nonisolated private static let changeActionID = "CHANGE_ACTION"
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
+        category: "ToastWindowController"
+    )
 
     override init() {
         super.init()
@@ -27,9 +33,9 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
 
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error {
-                print("Notification auth error: \(error)")
+                Self.logger.error("Notification auth error: \(error)")
             }
-            print("Notification permission granted: \(granted)")
+            Self.logger.notice("Notification permission granted: \(granted)")
         }
     }
 
@@ -56,7 +62,7 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
 
         UNUserNotificationCenter.current().add(request) { error in
             if let error {
-                print("Failed to add notification: \(error)")
+                Self.logger.error("Failed to add notification: \(error)")
                 return
             }
 
@@ -64,9 +70,8 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
                 return
             }
 
-            Task.detached {
-                let nanoseconds = UInt64(max(duration, 0) * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: nanoseconds)
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(duration))
                 UNUserNotificationCenter.current()
                     .removeDeliveredNotifications(withIdentifiers: [identifier])
             }

--- a/Sources/Snap/Views/SettingsView.swift
+++ b/Sources/Snap/Views/SettingsView.swift
@@ -57,20 +57,8 @@ struct SettingsView: View {
                 }
             }
         }
-        .task {
-            // Toggle debug details when option-clicking while on the Displays tab
-            let stream = AsyncStream<Void> { continuation in
-                let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                    if event.modifierFlags.contains(.option) {
-                        continuation.yield()
-                    }
-                    return event
-                }
-                continuation.onTermination = { _ in
-                    NSEvent.removeMonitor(monitor)
-                }
-            }
-            for await _ in stream where selectedTab == 1 {
+        .onChange(of: selectedTab) { _, newValue in
+            if newValue == 1, NSEvent.modifierFlags.contains(.option) {
                 showDebugDetails.toggle()
             }
         }

--- a/Sources/Snap/Views/SettingsView.swift
+++ b/Sources/Snap/Views/SettingsView.swift
@@ -14,15 +14,20 @@ struct SettingsView: View {
     @State private var entries: [(uuid: String, config: DisplayConfiguration)] = []
     @State private var settingsWindowBox = WeakWindowBox()
     @State private var settingsWindowID: ObjectIdentifier?
+    @State private var selectedTab = 0
+    @State private var showDebugDetails = false
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             generalTab
                 .tabItem { Label("General", systemImage: "gearshape") }
+                .tag(0)
             displaysTab
                 .tabItem { Label("Displays", systemImage: "display") }
+                .tag(1)
             aboutTab
                 .tabItem { Label("About", systemImage: "info.circle") }
+                .tag(2)
         }
         .frame(width: 460, height: 520)
         .onAppear {
@@ -50,6 +55,23 @@ struct SettingsView: View {
                 await MainActor.run {
                     entries = configStore.allEntries()
                 }
+            }
+        }
+        .task {
+            // Toggle debug details when option-clicking while on the Displays tab
+            let stream = AsyncStream<Void> { continuation in
+                let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                    if event.modifierFlags.contains(.option) {
+                        continuation.yield()
+                    }
+                    return event
+                }
+                continuation.onTermination = { _ in
+                    NSEvent.removeMonitor(monitor)
+                }
+            }
+            for await _ in stream where selectedTab == 1 {
+                showDebugDetails.toggle()
             }
         }
     }
@@ -122,6 +144,24 @@ struct SettingsView: View {
                                 }
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
+
+                                if showDebugDetails {
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(entry.uuid)
+                                        if let date = entry.config.lastConnected {
+                                            let stamp = date.formatted(
+                                                date: .abbreviated,
+                                                time: .shortened
+                                            )
+                                            Text("Last connected: \(stamp)")
+                                        } else {
+                                            Text("Last connected: unknown")
+                                        }
+                                    }
+                                    .font(.system(size: 10, design: .monospaced))
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.top, 2)
+                                }
                             }
 
                             Spacer()

--- a/Tests/SnapTests/DisplayConfigStoreTests.swift
+++ b/Tests/SnapTests/DisplayConfigStoreTests.swift
@@ -1,0 +1,192 @@
+@testable import Snap
+import Foundation
+import Testing
+
+@MainActor
+struct DisplayConfigStoreTests {
+    // MARK: - Helpers
+
+    private func makeTempFileURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SnapTests-\(UUID().uuidString)", isDirectory: true)
+        return dir.appendingPathComponent("displays.plist")
+    }
+
+    private func cleanup(_ url: URL) {
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func makeConfig(
+        mode: DisplayConfiguration.Mode = .extend,
+        preset: DisplayConfiguration.ExtendPreset = .externalRight,
+        mirror: DisplayConfiguration.MirrorTarget = .macBook,
+        remember: Bool = true
+    ) -> DisplayConfiguration {
+        DisplayConfiguration(
+            mode: mode,
+            extendPreset: preset,
+            mirrorTarget: mirror,
+            rememberThisDisplay: remember
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test("New store returns nil for unknown UUID")
+    func emptyStoreReturnsNil() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store = DisplayConfigStore(fileURL: url)
+        #expect(store.configuration(for: "nonexistent") == nil)
+    }
+
+    @Test("Save and retrieve preserves all fields")
+    func saveAndRetrieve() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store = DisplayConfigStore(fileURL: url)
+        let config = makeConfig(mode: .mirror, preset: .externalLeft, mirror: .external, remember: false)
+        let uuid = "test-uuid-1"
+
+        store.save(config, for: uuid)
+        let retrieved = store.configuration(for: uuid)
+
+        #expect(retrieved != nil)
+        #expect(retrieved?.mode == .mirror)
+        #expect(retrieved?.extendPreset == .externalLeft)
+        #expect(retrieved?.mirrorTarget == .external)
+        #expect(retrieved?.rememberThisDisplay == false)
+    }
+
+    @Test("Save overwrites previous config for same UUID")
+    func saveOverwrites() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store = DisplayConfigStore(fileURL: url)
+        let uuid = "overwrite-uuid"
+
+        store.save(makeConfig(mode: .extend), for: uuid)
+        store.save(makeConfig(mode: .mirror, preset: .externalAbove, mirror: .external, remember: false), for: uuid)
+
+        let retrieved = store.configuration(for: uuid)
+        #expect(retrieved?.mode == .mirror)
+        #expect(retrieved?.extendPreset == .externalAbove)
+        #expect(retrieved?.mirrorTarget == .external)
+        #expect(retrieved?.rememberThisDisplay == false)
+    }
+
+    @Test("Remove deletes only the specified UUID")
+    func removeSpecificUUID() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store = DisplayConfigStore(fileURL: url)
+        store.save(makeConfig(), for: "uuid-1")
+        store.save(makeConfig(), for: "uuid-2")
+
+        store.remove(for: "uuid-1")
+
+        #expect(store.configuration(for: "uuid-1") == nil)
+        #expect(store.configuration(for: "uuid-2") != nil)
+    }
+
+    @Test("RemoveAll clears all entries")
+    func removeAll() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store = DisplayConfigStore(fileURL: url)
+        store.save(makeConfig(), for: "a")
+        store.save(makeConfig(), for: "b")
+        store.save(makeConfig(), for: "c")
+
+        store.removeAll()
+
+        #expect(store.allEntries().isEmpty)
+    }
+
+    @Test("AllEntries returns all saved configs")
+    func allEntries() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store = DisplayConfigStore(fileURL: url)
+        store.save(makeConfig(mode: .extend), for: "uuid-1")
+        store.save(makeConfig(mode: .mirror), for: "uuid-2")
+        store.save(makeConfig(preset: .externalAbove), for: "uuid-3")
+
+        let entries = store.allEntries()
+        let uuids = Set(entries.map(\.uuid))
+
+        #expect(entries.count == 3)
+        #expect(uuids == Set(["uuid-1", "uuid-2", "uuid-3"]))
+    }
+
+    @Test("Data persists across separate store instances")
+    func persistenceAcrossInstances() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let store1 = DisplayConfigStore(fileURL: url)
+        store1.save(makeConfig(mode: .mirror, preset: .externalLeft), for: "persist-uuid")
+
+        let store2 = DisplayConfigStore(fileURL: url)
+        let retrieved = store2.configuration(for: "persist-uuid")
+
+        #expect(retrieved != nil)
+        #expect(retrieved?.mode == .mirror)
+        #expect(retrieved?.extendPreset == .externalLeft)
+    }
+
+    @Test("Corrupted plist does not crash, yields empty store")
+    func corruptedPlist() throws {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        let dir = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("not a valid plist at all!!!".utf8).write(to: url)
+
+        let store = DisplayConfigStore(fileURL: url)
+
+        #expect(store.configuration(for: "anything") == nil)
+        #expect(store.allEntries().isEmpty)
+    }
+
+    @Test("Missing file is not an error — creates empty store")
+    func missingFileIsNotError() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        // File does not exist yet
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+
+        let store = DisplayConfigStore(fileURL: url)
+        #expect(store.allEntries().isEmpty)
+    }
+
+    @Test("Optional fields are preserved through save/retrieve")
+    func optionalFieldsPreserved() {
+        let url = makeTempFileURL()
+        defer { cleanup(url) }
+
+        var config = makeConfig()
+        config.displayName = "LG UltraWide"
+        config.resolutionWidth = 3440
+        config.resolutionHeight = 1440
+        config.screenSizeInches = 34
+
+        let store = DisplayConfigStore(fileURL: url)
+        store.save(config, for: "optional-uuid")
+
+        let retrieved = store.configuration(for: "optional-uuid")
+        #expect(retrieved?.displayName == "LG UltraWide")
+        #expect(retrieved?.resolutionWidth == 3440)
+        #expect(retrieved?.resolutionHeight == 1440)
+        #expect(retrieved?.screenSizeInches == 34)
+    }
+}

--- a/Tests/SnapTests/DisplayConfigStoreTests.swift
+++ b/Tests/SnapTests/DisplayConfigStoreTests.swift
@@ -1,5 +1,5 @@
-@testable import Snap
 import Foundation
+@testable import Snap
 import Testing
 
 @MainActor

--- a/Tests/SnapTests/DisplayConfigurationTests.swift
+++ b/Tests/SnapTests/DisplayConfigurationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import Snap
 import Testing
 
@@ -166,5 +167,74 @@ struct DisplayConfigurationTests {
         let data = try PropertyListEncoder().encode(config)
         let decoded = try PropertyListDecoder().decode(DisplayConfiguration.self, from: data)
         #expect(decoded.rememberThisDisplay == false)
+    }
+
+    // MARK: - Backwards Compatibility
+
+    @Test("Decoding plist without optional fields succeeds with nils")
+    func decodeWithoutOptionalFields() throws {
+        let dict: [String: Any] = [
+            "mode": "extend",
+            "extendPreset": "externalRight",
+            "mirrorTarget": "macBook",
+            "rememberThisDisplay": true
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+        let decoded = try PropertyListDecoder().decode(DisplayConfiguration.self, from: data)
+
+        #expect(decoded.mode == .extend)
+        #expect(decoded.extendPreset == .externalRight)
+        #expect(decoded.mirrorTarget == .macBook)
+        #expect(decoded.rememberThisDisplay == true)
+        #expect(decoded.displayName == nil)
+        #expect(decoded.resolutionWidth == nil)
+        #expect(decoded.resolutionHeight == nil)
+        #expect(decoded.screenSizeInches == nil)
+        #expect(decoded.lastConnected == nil)
+    }
+
+    @Test("Round-trip preserves all optional fields when populated")
+    func roundTripAllOptionalFields() throws {
+        let now = Date()
+        let config = DisplayConfiguration(
+            mode: .extend,
+            extendPreset: .externalLeft,
+            mirrorTarget: .external,
+            rememberThisDisplay: false,
+            displayName: "DELL U2723QE",
+            resolutionWidth: 3840,
+            resolutionHeight: 2160,
+            screenSizeInches: 27,
+            lastConnected: now
+        )
+        let data = try PropertyListEncoder().encode(config)
+        let decoded = try PropertyListDecoder().decode(DisplayConfiguration.self, from: data)
+
+        #expect(decoded.displayName == "DELL U2723QE")
+        #expect(decoded.resolutionWidth == 3840)
+        #expect(decoded.resolutionHeight == 2160)
+        #expect(decoded.screenSizeInches == 27)
+        #expect(decoded.lastConnected != nil)
+        let delta = try abs(#require(decoded.lastConnected?.timeIntervalSince(now)))
+        #expect(delta < 1, "lastConnected should round-trip within 1s")
+    }
+
+    @Test("Round-trip with partial optional fields preserves set values and keeps others nil")
+    func roundTripPartialOptionalFields() throws {
+        let config = DisplayConfiguration(
+            mode: .mirror,
+            extendPreset: .externalAbove,
+            mirrorTarget: .macBook,
+            rememberThisDisplay: true,
+            displayName: "LG 5K",
+            screenSizeInches: 27
+        )
+        let data = try PropertyListEncoder().encode(config)
+        let decoded = try PropertyListDecoder().decode(DisplayConfiguration.self, from: data)
+
+        #expect(decoded.displayName == "LG 5K")
+        #expect(decoded.screenSizeInches == 27)
+        #expect(decoded.resolutionWidth == nil)
+        #expect(decoded.resolutionHeight == nil)
     }
 }

--- a/Tests/SnapTests/DisplayConfigurationTests.swift
+++ b/Tests/SnapTests/DisplayConfigurationTests.swift
@@ -177,7 +177,7 @@ struct DisplayConfigurationTests {
             "mode": "extend",
             "extendPreset": "externalRight",
             "mirrorTarget": "macBook",
-            "rememberThisDisplay": true
+            "rememberThisDisplay": true,
         ]
         let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
         let decoded = try PropertyListDecoder().decode(DisplayConfiguration.self, from: data)

--- a/Tests/SnapTests/DisplayConfigurationTests.swift
+++ b/Tests/SnapTests/DisplayConfigurationTests.swift
@@ -177,7 +177,7 @@ struct DisplayConfigurationTests {
             "mode": "extend",
             "extendPreset": "externalRight",
             "mirrorTarget": "macBook",
-            "rememberThisDisplay": true,
+            "rememberThisDisplay": true
         ]
         let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
         let decoded = try PropertyListDecoder().decode(DisplayConfiguration.self, from: data)

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -1,6 +1,6 @@
-@testable import Snap
 import CoreGraphics
 import Foundation
+@testable import Snap
 import Testing
 
 // MARK: - Mock
@@ -8,7 +8,7 @@ import Testing
 @MainActor
 final class MockDisplayTransactor: DisplayTransacting {
     // nonisolated(unsafe) so deinit can deallocate without a Sendable warning
-    private nonisolated(unsafe) let dummyRaw: UnsafeMutableRawPointer
+    nonisolated(unsafe) private let dummyRaw: UnsafeMutableRawPointer
     private let dummyRef: CGDisplayConfigRef
 
     var beginShouldSucceed = true
@@ -36,15 +36,15 @@ final class MockDisplayTransactor: DisplayTransacting {
         return beginShouldSucceed ? dummyRef : nil
     }
 
-    func configureOrigin(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32) {
+    func configureOrigin(_: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32) {
         originCalls.append((display: display, x: x, y: y))
     }
 
-    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID) {
+    func configureMirror(_: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID) {
         mirrorCalls.append((display: display, master: master))
     }
 
-    func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool {
+    func completeConfiguration(_: CGDisplayConfigRef) -> Bool {
         completeCalled = true
         return completeShouldSucceed
     }
@@ -97,7 +97,7 @@ struct DisplayConfiguratorTests {
         let call = mock.originCalls[0]
         #expect(call.display == externalID)
         #expect(call.x == 1440)
-        #expect(call.y == -270)  // (900/2 - 1440/2) = -270
+        #expect(call.y == -270) // (900/2 - 1440/2) = -270
     }
 
     @Test("Extend left places external to the left, vertically centred")
@@ -110,7 +110,7 @@ struct DisplayConfiguratorTests {
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
         #expect(call.display == externalID)
-        #expect(call.x == -2560)  // 0 - 2560
+        #expect(call.x == -2560) // 0 - 2560
         #expect(call.y == -270)
     }
 
@@ -124,8 +124,8 @@ struct DisplayConfiguratorTests {
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
         #expect(call.display == externalID)
-        #expect(call.x == -560)   // (1440/2 - 2560/2) = -560
-        #expect(call.y == -1440)  // 0 - 1440
+        #expect(call.x == -560) // (1440/2 - 2560/2) = -560
+        #expect(call.y == -1440) // 0 - 1440
     }
 
     @Test("Extend always unmirrors first before positioning")

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -1,0 +1,209 @@
+@testable import Snap
+import CoreGraphics
+import Foundation
+import Testing
+
+// MARK: - Mock
+
+@MainActor
+final class MockDisplayTransactor: DisplayTransacting {
+    // nonisolated(unsafe) so deinit can deallocate without a Sendable warning
+    private nonisolated(unsafe) let dummyRaw: UnsafeMutableRawPointer
+    private let dummyRef: CGDisplayConfigRef
+
+    var beginShouldSucceed = true
+    var completeShouldSucceed = true
+
+    var originCalls: [(display: CGDirectDisplayID, x: Int32, y: Int32)] = []
+    var mirrorCalls: [(display: CGDirectDisplayID, master: CGDirectDisplayID)] = []
+    var boundsCalls: [CGDirectDisplayID] = []
+    var beginCalled = false
+    var completeCalled = false
+
+    var boundsMap: [CGDirectDisplayID: CGRect] = [:]
+
+    init() {
+        dummyRaw = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+        dummyRef = OpaquePointer(dummyRaw)
+    }
+
+    deinit {
+        dummyRaw.deallocate()
+    }
+
+    func beginConfiguration() -> CGDisplayConfigRef? {
+        beginCalled = true
+        return beginShouldSucceed ? dummyRef : nil
+    }
+
+    func configureOrigin(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32) {
+        originCalls.append((display: display, x: x, y: y))
+    }
+
+    func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID) {
+        mirrorCalls.append((display: display, master: master))
+    }
+
+    func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool {
+        completeCalled = true
+        return completeShouldSucceed
+    }
+
+    func displayBounds(_ display: CGDirectDisplayID) -> CGRect {
+        boundsCalls.append(display)
+        return boundsMap[display] ?? .zero
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+struct DisplayConfiguratorTests {
+    private let primaryID: CGDirectDisplayID = 1
+    private let externalID: CGDirectDisplayID = 2
+    private let internalBounds = CGRect(x: 0, y: 0, width: 1440, height: 900)
+    private let externalBounds = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+
+    private func makeTransactor() -> MockDisplayTransactor {
+        let mock = MockDisplayTransactor()
+        mock.boundsMap[primaryID] = internalBounds
+        mock.boundsMap[externalID] = externalBounds
+        return mock
+    }
+
+    private func makeConfig(
+        mode: DisplayConfiguration.Mode,
+        preset: DisplayConfiguration.ExtendPreset = .externalRight,
+        mirror: DisplayConfiguration.MirrorTarget = .macBook
+    ) -> DisplayConfiguration {
+        DisplayConfiguration(
+            mode: mode,
+            extendPreset: preset,
+            mirrorTarget: mirror,
+            rememberThisDisplay: false
+        )
+    }
+
+    // MARK: - Extend
+
+    @Test("Extend right places external at right edge, vertically centred")
+    func extendRight() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .extend, preset: .externalRight)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.originCalls.count == 1)
+        let call = mock.originCalls[0]
+        #expect(call.display == externalID)
+        #expect(call.x == 1440)
+        #expect(call.y == -270)  // (900/2 - 1440/2) = -270
+    }
+
+    @Test("Extend left places external to the left, vertically centred")
+    func extendLeft() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .extend, preset: .externalLeft)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.originCalls.count == 1)
+        let call = mock.originCalls[0]
+        #expect(call.display == externalID)
+        #expect(call.x == -2560)  // 0 - 2560
+        #expect(call.y == -270)
+    }
+
+    @Test("Extend above places external centred on top")
+    func extendAbove() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .extend, preset: .externalAbove)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.originCalls.count == 1)
+        let call = mock.originCalls[0]
+        #expect(call.display == externalID)
+        #expect(call.x == -560)   // (1440/2 - 2560/2) = -560
+        #expect(call.y == -1440)  // 0 - 1440
+    }
+
+    @Test("Extend always unmirrors first before positioning")
+    func extendUnmirrorsFirst() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .extend, preset: .externalRight)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.mirrorCalls.count == 1)
+        let unmirror = mock.mirrorCalls[0]
+        #expect(unmirror.display == externalID)
+        #expect(unmirror.master == kCGNullDirectDisplay)
+    }
+
+    // MARK: - Mirror
+
+    @Test("Mirror macBook mirrors external to primary")
+    func mirrorMacBook() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .mirror, mirror: .macBook)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.mirrorCalls.count == 1)
+        #expect(mock.mirrorCalls[0].display == externalID)
+        #expect(mock.mirrorCalls[0].master == primaryID)
+        #expect(mock.originCalls.isEmpty)
+    }
+
+    @Test("Mirror external mirrors primary to external")
+    func mirrorExternal() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .mirror, mirror: .external)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.mirrorCalls.count == 1)
+        #expect(mock.mirrorCalls[0].display == primaryID)
+        #expect(mock.mirrorCalls[0].master == externalID)
+        #expect(mock.originCalls.isEmpty)
+    }
+
+    // MARK: - Transaction lifecycle
+
+    @Test("Begin failure aborts without configuring or completing")
+    func beginFailure() {
+        let mock = makeTransactor()
+        mock.beginShouldSucceed = false
+        let config = makeConfig(mode: .extend)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.beginCalled)
+        #expect(mock.originCalls.isEmpty)
+        #expect(mock.mirrorCalls.isEmpty)
+        #expect(!mock.completeCalled)
+    }
+
+    @Test("Complete failure still calls complete (logs error)")
+    func completeFailure() {
+        let mock = makeTransactor()
+        mock.completeShouldSucceed = false
+        let config = makeConfig(mode: .extend, preset: .externalRight)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.completeCalled)
+        #expect(mock.originCalls.count == 1)
+    }
+
+    @Test("Successful apply calls complete")
+    func completeSuccess() {
+        let mock = makeTransactor()
+        let config = makeConfig(mode: .extend, preset: .externalRight)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.completeCalled)
+    }
+}

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import Foundation
 @testable import Snap
 import Testing
 

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -7,6 +7,17 @@ import Testing
 
 @MainActor
 final class MockDisplayTransactor: DisplayTransacting {
+    struct OriginCall {
+        let display: CGDirectDisplayID
+        let x: Int32
+        let y: Int32
+    }
+
+    struct MirrorCall {
+        let display: CGDirectDisplayID
+        let primary: CGDirectDisplayID
+    }
+
     // nonisolated(unsafe) so deinit can deallocate without a Sendable warning
     nonisolated(unsafe) private let dummyRaw: UnsafeMutableRawPointer
     private let dummyRef: CGDisplayConfigRef
@@ -14,8 +25,8 @@ final class MockDisplayTransactor: DisplayTransacting {
     var beginShouldSucceed = true
     var completeShouldSucceed = true
 
-    var originCalls: [(display: CGDirectDisplayID, x: Int32, y: Int32)] = []
-    var mirrorCalls: [(display: CGDirectDisplayID, master: CGDirectDisplayID)] = []
+    var originCalls: [OriginCall] = []
+    var mirrorCalls: [MirrorCall] = []
     var boundsCalls: [CGDirectDisplayID] = []
     var beginCalled = false
     var completeCalled = false
@@ -37,11 +48,11 @@ final class MockDisplayTransactor: DisplayTransacting {
     }
 
     func configureOrigin(_: CGDisplayConfigRef, display: CGDirectDisplayID, x: Int32, y: Int32) {
-        originCalls.append((display: display, x: x, y: y))
+        originCalls.append(OriginCall(display: display, x: x, y: y))
     }
 
-    func configureMirror(_: CGDisplayConfigRef, display: CGDirectDisplayID, master: CGDirectDisplayID) {
-        mirrorCalls.append((display: display, master: master))
+    func configureMirror(_: CGDisplayConfigRef, display: CGDirectDisplayID, primary: CGDirectDisplayID) {
+        mirrorCalls.append(MirrorCall(display: display, primary: primary))
     }
 
     func completeConfiguration(_: CGDisplayConfigRef) -> Bool {
@@ -138,7 +149,7 @@ struct DisplayConfiguratorTests {
         #expect(mock.mirrorCalls.count == 1)
         let unmirror = mock.mirrorCalls[0]
         #expect(unmirror.display == externalID)
-        #expect(unmirror.master == kCGNullDirectDisplay)
+        #expect(unmirror.primary == kCGNullDirectDisplay)
     }
 
     // MARK: - Mirror
@@ -152,7 +163,7 @@ struct DisplayConfiguratorTests {
 
         #expect(mock.mirrorCalls.count == 1)
         #expect(mock.mirrorCalls[0].display == externalID)
-        #expect(mock.mirrorCalls[0].master == primaryID)
+        #expect(mock.mirrorCalls[0].primary == primaryID)
         #expect(mock.originCalls.isEmpty)
     }
 
@@ -165,7 +176,7 @@ struct DisplayConfiguratorTests {
 
         #expect(mock.mirrorCalls.count == 1)
         #expect(mock.mirrorCalls[0].display == primaryID)
-        #expect(mock.mirrorCalls[0].master == externalID)
+        #expect(mock.mirrorCalls[0].primary == externalID)
         #expect(mock.originCalls.isEmpty)
     }
 

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -7,11 +7,18 @@ import Testing
 
 @MainActor
 private final class MockDisplayMonitorDelegate: DisplayMonitorDelegate {
-    var connectCalls: [(id: CGDirectDisplayID, uuid: String, name: String, resolution: CGSize)] = []
+    struct ConnectCall {
+        let id: CGDirectDisplayID
+        let uuid: String
+        let name: String
+        let resolution: CGSize
+    }
+
+    var connectCalls: [ConnectCall] = []
     var disconnectCalls: [CGDirectDisplayID] = []
 
     func displayDidConnect(id: CGDirectDisplayID, uuid: String, name: String, resolution: CGSize) {
-        connectCalls.append((id: id, uuid: uuid, name: name, resolution: resolution))
+        connectCalls.append(ConnectCall(id: id, uuid: uuid, name: name, resolution: resolution))
     }
 
     func displayDidDisconnect(id: CGDirectDisplayID) {

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -1,0 +1,181 @@
+import CoreGraphics
+import Foundation
+@testable import Snap
+import Testing
+
+// MARK: - Mock delegate
+
+@MainActor
+private final class MockDisplayMonitorDelegate: DisplayMonitorDelegate {
+    var connectCalls: [(id: CGDirectDisplayID, uuid: String, name: String, resolution: CGSize)] = []
+    var disconnectCalls: [CGDirectDisplayID] = []
+
+    func displayDidConnect(id: CGDirectDisplayID, uuid: String, name: String, resolution: CGSize) {
+        connectCalls.append((id: id, uuid: uuid, name: name, resolution: resolution))
+    }
+
+    func displayDidDisconnect(id: CGDirectDisplayID) {
+        disconnectCalls.append(id)
+    }
+}
+
+// MARK: - Tests
+
+/// Non-built-in display IDs used in tests.
+/// High IDs that won't match any real display, so `CGDisplayIsBuiltin` returns 0.
+private let fakeDisplayA: CGDirectDisplayID = 999
+private let fakeDisplayB: CGDirectDisplayID = 998
+
+/// Slightly longer than the debounce interval to let it settle.
+private let testDebounce: Duration = .milliseconds(100)
+private let debounceWait: Duration = .milliseconds(250)
+
+@MainActor
+struct DisplayMonitorDebounceTests {
+    private func makeSUT(
+        isOnline: @escaping @Sendable (CGDirectDisplayID) -> Bool = { _ in true }
+    ) -> (monitor: DisplayMonitor, delegate: MockDisplayMonitorDelegate) {
+        let monitor = DisplayMonitor(
+            debounceInterval: testDebounce,
+            isBuiltIn: { $0 == CGMainDisplayID() },
+            isOnline: isOnline
+        )
+        let delegate = MockDisplayMonitorDelegate()
+        monitor.delegate = delegate
+        return (monitor, delegate)
+    }
+
+    // MARK: - Connect
+
+    @Test("Single connect dispatches after debounce")
+    func singleConnect() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+
+        // Immediately — debounce hasn't fired yet.
+        #expect(delegate.connectCalls.isEmpty)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.count == 1)
+        #expect(delegate.connectCalls.first?.id == fakeDisplayA)
+    }
+
+    @Test("Rapid connect events for same display coalesce into one")
+    func rapidConnectsCoalesce() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.count == 1)
+    }
+
+    @Test("Different displays dispatch independently")
+    func differentDisplaysIndependent() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayB, flags: .addFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        let ids = Set(delegate.connectCalls.map(\.id))
+        #expect(ids == [fakeDisplayA, fakeDisplayB])
+    }
+
+    // MARK: - Disconnect
+
+    @Test("Single disconnect dispatches after debounce")
+    func singleDisconnect() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .removeFlag)
+
+        #expect(delegate.disconnectCalls.isEmpty)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.disconnectCalls.count == 1)
+        #expect(delegate.disconnectCalls.first == fakeDisplayA)
+    }
+
+    // MARK: - Event replacement
+
+    @Test("Disconnect replaces pending connect for same display")
+    func disconnectReplacesConnect() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .removeFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.isEmpty, "Connect should have been cancelled")
+        #expect(delegate.disconnectCalls.count == 1)
+        #expect(delegate.disconnectCalls.first == fakeDisplayA)
+    }
+
+    // MARK: - Built-in filter
+
+    @Test("Built-in display is filtered out")
+    func builtInFiltered() async throws {
+        let builtInID: CGDirectDisplayID = 42
+        let monitor = DisplayMonitor(
+            debounceInterval: testDebounce,
+            isBuiltIn: { $0 == builtInID },
+            isOnline: { _ in true }
+        )
+        let delegate = MockDisplayMonitorDelegate()
+        monitor.delegate = delegate
+
+        monitor.handleReconfiguration(displayID: builtInID, flags: .addFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.isEmpty)
+        #expect(delegate.disconnectCalls.isEmpty)
+    }
+
+    // MARK: - Post-debounce validation
+
+    @Test("Phantom display gone during debounce does not trigger connect")
+    func phantomDisplayDropped() async throws {
+        // Display goes offline before debounce fires
+        let (monitor, delegate) = makeSUT(isOnline: { _ in false })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.isEmpty, "Offline display should not trigger connect")
+    }
+
+    @Test("Display that stays online triggers connect normally")
+    func onlineDisplayConnects() async throws {
+        let (monitor, delegate) = makeSUT(isOnline: { _ in true })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.count == 1)
+        #expect(delegate.connectCalls.first?.id == fakeDisplayA)
+    }
+
+    @Test("Disconnect events skip online check")
+    func disconnectSkipsOnlineCheck() async throws {
+        // isOnline returns false, but disconnects should still fire
+        let (monitor, delegate) = makeSUT(isOnline: { _ in false })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .removeFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.disconnectCalls.count == 1, "Disconnect should fire regardless of online status")
+    }
+}

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import Foundation
 @testable import Snap
 import Testing
 


### PR DESCRIPTION
The `NSEvent.addLocalMonitorForEvents` approach toggled `showDebugDetails` on any Option+click anywhere in the window while the Displays tab was visible — not just on the tab item itself — causing accidental toggles from clicks inside the list or on buttons.

## Change

Replaced the local event monitor with `.onChange(of: selectedTab)` + a modifier flag check, so the toggle only fires when the user switches **to** the Displays tab while holding Option:

```swift
// Before: fires on any Option+leftMouseDown in the entire window
.task {
    let stream = AsyncStream<Void> { continuation in
        let monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
            if event.modifierFlags.contains(.option) { continuation.yield() }
            return event
        }
        ...
    }
    for await _ in stream where selectedTab == 1 { showDebugDetails.toggle() }
}

// After: fires only on tab switch to Displays with Option held
.onChange(of: selectedTab) { _, newValue in
    if newValue == 1, NSEvent.modifierFlags.contains(.option) {
        showDebugDetails.toggle()
    }
}
```

This also removes the async stream and monitor lifecycle boilerplate entirely.