### PR TITLE
feat: in-app diagnostics logging with ring buffer and Settings tab

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,10 @@
 - All async code uses Swift Concurrency: async/await, actors, structured concurrency.
 - Universal binary: Apple Silicon + Intel (`arm64 x86_64`).
 
+## Code Review
+Design decisions are documented as ADRs in `docs/decisions/`. Key rules:
+- Do not flag `privacy: .public` on os.Logger calls — intentional per ADR-001.
+
 ## Architecture
 - AppKit + SwiftUI hybrid. The app uses `NSApplicationDelegate`, `NSStatusItem`, `NSPanel`, and `NSHostingView` to host SwiftUI views.
 - No pure SwiftUI `@main App` lifecycle — the entry point is `SnapApp.swift` using `@main` with a custom `static func main()` that calls `NSApplication.shared.run()`.
@@ -70,21 +74,10 @@
 
 ## Build & Run
 
-After making code changes, always build and verify. Kill existing instances before re-launching.
-
 ```bash
-# Regenerate Xcode project from project.yml (if project.yml changed)
-xcodegen generate
-
-# Build
+xcodegen generate  # only if project.yml changed
 xcodebuild -project Snap.xcodeproj -scheme Snap -configuration Debug build
-
-# Run (kill existing first)
-pkill -x Snap 2>/dev/null; sleep 0.5
-open "$(xcodebuild -project Snap.xcodeproj -scheme Snap -configuration Debug -showBuildSettings 2>/dev/null | grep ' BUILT_PRODUCTS_DIR' | awk '{print $3}')/Snap.app"
-
-# Tests
 xcodebuild -project Snap.xcodeproj -scheme Snap -configuration Debug test
 ```
 
-For display-related changes, remind Luke to plug/unplug an external display to test detection.
+For display changes, test with external display plug/unplug.

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -1,5 +1,4 @@
 import AppKit
-import os
 import ServiceManagement
 import Sparkle
 
@@ -21,10 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         userDriverDelegate: nil
     )
 
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
-        category: "AppDelegate"
-    )
+    private static let logger = SnapLogger(category: "AppDelegate")
 
     func applicationDidFinishLaunching(_: Notification) {
         // Skip UI and hardware setup when running as a unit test host
@@ -52,7 +48,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Prompt, toast, and settings controllers
         promptController = PromptWindowController()
         toastController = ToastWindowController()
-        settingsController = SettingsWindowController(configStore: configStore, updaterController: updaterController)
+        settingsController = SettingsWindowController(
+            configStore: configStore,
+            logStore: LogStore.shared,
+            updaterController: updaterController
+        )
         menuBar.onOpenSettings = { [weak self] in
             self?.settingsController?.show()
         }

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -10,7 +10,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var promptController: PromptWindowController?
     private var toastController: ToastWindowController?
     private var settingsController: SettingsWindowController?
-    private let configStore = DisplayConfigStore()
+    private let logStore = LogStore()
+    private lazy var configStore = DisplayConfigStore(logStore: logStore)
     private var currentDisplay: ConnectedDisplay?
     private var pendingToastTask: Task<Void, Never>?
 
@@ -20,12 +21,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         userDriverDelegate: nil
     )
 
-    private static let logger = SnapLogger(category: "AppDelegate")
+    private lazy var logger = SnapLogger(category: "AppDelegate", logStore: logStore)
 
     func applicationDidFinishLaunching(_: Notification) {
         // Skip UI and hardware setup when running as a unit test host
         guard !isRunningTests else {
-            Self.logger.notice("Snap launched as test host — skipping UI setup")
+            logger.notice("Snap launched as test host — skipping UI setup")
             return
         }
 
@@ -38,7 +39,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.toastController?.show(
                 message: "External Display — extend right applied",
                 onChangeTapped: {
-                    Self.logger.notice("Change tapped from test notification")
+                    self?.logger.notice("Change tapped from test notification")
                 }
             )
         }
@@ -47,10 +48,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Prompt, toast, and settings controllers
         promptController = PromptWindowController()
-        toastController = ToastWindowController()
+        toastController = ToastWindowController(logStore: logStore)
         settingsController = SettingsWindowController(
             configStore: configStore,
-            logStore: LogStore.shared,
+            logStore: logStore,
             updaterController: updaterController
         )
         menuBar.onOpenSettings = { [weak self] in
@@ -58,7 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Display monitoring
-        let monitor = DisplayMonitor()
+        let monitor = DisplayMonitor(logStore: logStore)
         monitor.delegate = self
         monitor.startMonitoring()
         displayMonitor = monitor
@@ -69,7 +70,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // First-run: ask user to enable launch at login
         promptLaunchAtLoginIfNeeded()
 
-        Self.logger.notice("Snap started")
+        logger.notice("Snap started")
     }
 
     func applicationWillTerminate(_: Notification) {
@@ -109,9 +110,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if response == .alertFirstButtonReturn {
             do {
                 try SMAppService.mainApp.register()
-                Self.logger.notice("Launch at login enabled via first-run prompt")
+                logger.notice("Launch at login enabled via first-run prompt")
             } catch {
-                Self.logger.error("Failed to enable launch at login: \(error)")
+                logger.error("Failed to enable launch at login: \(error)")
             }
         }
     }
@@ -130,8 +131,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onApply: { [weak self] config in
                 self?.applyAndSave(config: config, displayID: displayID, uuid: uuid, name: name, resolution: resolution)
             },
-            onDismiss: {
-                Self.logger.notice("Prompt dismissed for \(name)")
+            onDismiss: { [weak self] in
+                self?.logger.notice("Prompt dismissed for \(name)")
             }
         )
     }
@@ -146,20 +147,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Guard against stale prompts — the display may have gone offline
         // (e.g. phantom during sleep/wake) since the prompt was shown.
         guard isDisplayOnline(displayID) else {
-            Self.logger.warning("Display \(displayID) [\(uuid)] is offline — skipping apply and save")
+            logger.warning("Display \(displayID) [\(uuid)] is offline — skipping apply and save")
             return
         }
         if let monitor = displayMonitor {
             let currentUUID = monitor.displayUUID(for: displayID)
             guard currentUUID == uuid else {
-                Self.logger.warning(
+                logger.warning(
                     "Display \(displayID) UUID changed (\(uuid) → \(currentUUID)) — skipping apply and save"
                 )
                 return
             }
         }
 
-        DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID)
+        DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID, logger: logger)
 
         // Save the config so the display appears in Settings.
         // rememberThisDisplay controls whether to auto-apply silently next time.
@@ -176,7 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         savedConfig.screenSizeInches = Int(diagonalInches.rounded())
         savedConfig.lastConnected = Date()
         configStore.save(savedConfig, for: uuid)
-        Self.logger.notice("Saved config for \(name) [\(uuid)] (auto-apply: \(config.rememberThisDisplay))")
+        logger.notice("Saved config for \(name) [\(uuid)] (auto-apply: \(config.rememberThisDisplay))")
 
         currentDisplay = ConnectedDisplay(
             id: displayID, uuid: uuid, name: name, resolution: resolution, appliedConfig: config
@@ -222,13 +223,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard CGGetOnlineDisplayList(0, nil, &displayCount) == .success,
               displayCount > 0
         else {
-            Self.logger.notice("No online displays found at launch")
+            logger.notice("No online displays found at launch")
             return
         }
 
         var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
         guard CGGetOnlineDisplayList(displayCount, &displayIDs, &displayCount) == .success else {
-            Self.logger.error("Failed to enumerate online displays")
+            logger.error("Failed to enumerate online displays")
             return
         }
 
@@ -236,7 +237,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let uuid = monitor.displayUUID(for: id)
             let name = monitor.displayName(for: id)
             let bounds = CGDisplayBounds(id)
-            Self.logger.notice(
+            logger.notice(
                 "Found external display at launch: \(name) [\(uuid)]"
             )
             displayDidConnect(
@@ -258,14 +259,14 @@ extension AppDelegate: DisplayMonitorDelegate {
         name: String,
         resolution: CGSize
     ) {
-        Self.logger.notice("Display connected: \(name) [\(uuid)]")
+        logger.notice("Display connected: \(name) [\(uuid)]")
 
         // Dismiss any stale prompt (e.g. from a phantom display during sleep/wake)
         promptController?.dismiss()
 
         if let savedConfig = configStore.configuration(for: uuid), savedConfig.rememberThisDisplay {
             // Known display with auto-apply — apply silently
-            DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id)
+            DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id, logger: logger)
 
             // Update lastConnected timestamp
             var updatedConfig = savedConfig
@@ -287,7 +288,7 @@ extension AppDelegate: DisplayMonitorDelegate {
                 let targetName = savedConfig.mirrorTarget.displayName.lowercased()
                 modeLabel = "\(modeName) \(targetName)"
             }
-            Self.logger.notice("Applied saved config: \(modeLabel)")
+            logger.notice("Applied saved config: \(modeLabel)")
 
             // Show toast after a brief delay — the display reconfiguration
             // invalidates screen geometry, so we wait for it to settle
@@ -298,7 +299,7 @@ extension AppDelegate: DisplayMonitorDelegate {
                 pendingToastTask = Task { @MainActor [weak self] in
                     try? await Task.sleep(for: .seconds(1.5))
                     guard !Task.isCancelled else { return }
-                    Self.logger.notice("Showing toast: \(toastMessage)")
+                    logger.notice("Showing toast: \(toastMessage)")
                     self?.toastController?.show(
                         message: toastMessage,
                         onChangeTapped: { [weak self] in
@@ -324,7 +325,7 @@ extension AppDelegate: DisplayMonitorDelegate {
 
         guard currentDisplay?.id == id else { return }
         let name = currentDisplay?.name ?? "unknown"
-        Self.logger.notice("Display disconnected: \(name) (ID \(id))")
+        logger.notice("Display disconnected: \(name) (ID \(id))")
         currentDisplay = nil
         menuBarController?.updateCurrentDisplay(nil)
     }

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -296,7 +296,7 @@ extension AppDelegate: DisplayMonitorDelegate {
             if showToast {
                 let toastMessage = "\(name) — \(modeLabel) applied"
                 pendingToastTask?.cancel()
-                pendingToastTask = Task { @MainActor [weak self] in
+                pendingToastTask = Task { @MainActor [weak self, logger] in
                     try? await Task.sleep(for: .seconds(1.5))
                     guard !Task.isCancelled else { return }
                     logger.notice("Showing toast: \(toastMessage)")

--- a/Sources/Snap/Diagnostics/LogStore.swift
+++ b/Sources/Snap/Diagnostics/LogStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+import os
+
+/// Thread-safe in-memory ring buffer for diagnostic log entries.
+///
+/// Uses `OSAllocatedUnfairLock` for synchronous, lock-based thread safety —
+/// safe to call from any thread including the CGDisplay reconfiguration callback.
+final class LogStore: Sendable {
+    static let shared = LogStore()
+
+    /// Maximum number of entries retained in the ring buffer.
+    let capacity: Int
+
+    enum Level: String, CaseIterable, Comparable {
+        case info
+        case notice
+        case warning
+        case error
+
+        static func < (lhs: Level, rhs: Level) -> Bool {
+            let order: [Level] = [.info, .notice, .warning, .error]
+            return order.firstIndex(of: lhs)! < order.firstIndex(of: rhs)!
+        }
+    }
+
+    struct Entry: Identifiable {
+        let id: UInt64
+        let timestamp: Date
+        let level: Level
+        let category: String
+        let message: String
+    }
+
+    private struct State {
+        var entries: [Entry] = []
+        var nextID: UInt64 = 0
+        let capacity: Int
+    }
+
+    private let state: OSAllocatedUnfairLock<State>
+
+    init(capacity: Int = 500) {
+        self.capacity = capacity
+        self.state = OSAllocatedUnfairLock(initialState: State(capacity: capacity))
+    }
+
+    func append(level: Level, category: String, message: String) {
+        state.withLock { st in
+            let entry = Entry(
+                id: st.nextID,
+                timestamp: Date(),
+                level: level,
+                category: category,
+                message: message
+            )
+            st.nextID += 1
+            st.entries.append(entry)
+            if st.entries.count > st.capacity {
+                st.entries.removeFirst(st.entries.count - st.capacity)
+            }
+        }
+    }
+
+    func entries() -> [Entry] {
+        state.withLock { $0.entries }
+    }
+
+    func clear() {
+        state.withLock { $0.entries.removeAll() }
+    }
+
+    /// Formats all entries as a plain-text diagnostic report for clipboard export.
+    func formattedReport() -> String {
+        let snapshot = entries()
+        guard !snapshot.isEmpty else { return "No diagnostic log entries." }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+
+        var lines = [
+            "Snap Diagnostic Log",
+            "Exported: \(formatter.string(from: Date()))",
+            "Entries: \(snapshot.count)",
+            String(repeating: "─", count: 72)
+        ]
+
+        for entry in snapshot {
+            let ts = formatter.string(from: entry.timestamp)
+            lines.append("\(ts) [\(entry.level.rawValue)] \(entry.category): \(entry.message)")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/Snap/Diagnostics/LogStore.swift
+++ b/Sources/Snap/Diagnostics/LogStore.swift
@@ -44,6 +44,7 @@ final class LogStore: Sendable {
         var head: Int = 0
         var count: Int = 0
         var nextID: UInt64 = 0
+        var generation: UInt64 = 0
         let capacity: Int
 
         init(capacity: Int) {
@@ -70,6 +71,7 @@ final class LogStore: Sendable {
                 message: message
             )
             st.nextID += 1
+            st.generation += 1
 
             let index = (st.head + st.count) % st.capacity
             if st.count < st.capacity {
@@ -93,7 +95,12 @@ final class LogStore: Sendable {
             st.buffer = Array(repeating: nil, count: st.capacity)
             st.head = 0
             st.count = 0
+            st.generation += 1
         }
+    }
+
+    var generation: UInt64 {
+        state.withLock { $0.generation }
     }
 
     /// Formats all entries as a plain-text diagnostic report for clipboard export.
@@ -101,21 +108,24 @@ final class LogStore: Sendable {
         let snapshot = entries()
         guard !snapshot.isEmpty else { return "No diagnostic log entries." }
 
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-
         var lines = [
             "Snap Diagnostic Log",
-            "Exported: \(formatter.string(from: Date()))",
+            "Exported: \(Self.reportFormatter.string(from: Date()))",
             "Entries: \(snapshot.count)",
             String(repeating: "─", count: 72)
         ]
 
         for entry in snapshot {
-            let ts = formatter.string(from: entry.timestamp)
+            let ts = Self.reportFormatter.string(from: entry.timestamp)
             lines.append("\(ts) [\(entry.level.rawValue)] \(entry.category): \(entry.message)")
         }
 
         return lines.joined(separator: "\n")
     }
+
+    private static let reportFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return fmt
+    }()
 }

--- a/Sources/Snap/Diagnostics/LogStore.swift
+++ b/Sources/Snap/Diagnostics/LogStore.swift
@@ -6,8 +6,6 @@ import os
 /// Uses `OSAllocatedUnfairLock` for synchronous, lock-based thread safety —
 /// safe to call from any thread including the CGDisplay reconfiguration callback.
 final class LogStore: Sendable {
-    static let shared = LogStore()
-
     /// Maximum number of entries retained in the ring buffer.
     let capacity: Int
 
@@ -17,9 +15,19 @@ final class LogStore: Sendable {
         case warning
         case error
 
+        /// Numeric severity used for ordering. Adding a new case requires
+        /// assigning it a rank — the compiler enforces exhaustive switching.
+        var rank: Int {
+            switch self {
+            case .info: 0
+            case .notice: 1
+            case .warning: 2
+            case .error: 3
+            }
+        }
+
         static func < (lhs: Level, rhs: Level) -> Bool {
-            let order: [Level] = [.info, .notice, .warning, .error]
-            return order.firstIndex(of: lhs)! < order.firstIndex(of: rhs)!
+            lhs.rank < rhs.rank
         }
     }
 
@@ -32,9 +40,16 @@ final class LogStore: Sendable {
     }
 
     private struct State {
-        var entries: [Entry] = []
+        var buffer: [Entry?]
+        var head: Int = 0
+        var count: Int = 0
         var nextID: UInt64 = 0
         let capacity: Int
+
+        init(capacity: Int) {
+            self.capacity = capacity
+            self.buffer = Array(repeating: nil, count: capacity)
+        }
     }
 
     private let state: OSAllocatedUnfairLock<State>
@@ -54,19 +69,30 @@ final class LogStore: Sendable {
                 message: message
             )
             st.nextID += 1
-            st.entries.append(entry)
-            if st.entries.count > st.capacity {
-                st.entries.removeFirst(st.entries.count - st.capacity)
+
+            let index = (st.head + st.count) % st.capacity
+            if st.count < st.capacity {
+                st.buffer[index] = entry
+                st.count += 1
+            } else {
+                st.buffer[st.head] = entry
+                st.head = (st.head + 1) % st.capacity
             }
         }
     }
 
     func entries() -> [Entry] {
-        state.withLock { $0.entries }
+        state.withLock { st in
+            (0 ..< st.count).map { st.buffer[(st.head + $0) % st.capacity]! }
+        }
     }
 
     func clear() {
-        state.withLock { $0.entries.removeAll() }
+        state.withLock { st in
+            st.buffer = Array(repeating: nil, count: st.capacity)
+            st.head = 0
+            st.count = 0
+        }
     }
 
     /// Formats all entries as a plain-text diagnostic report for clipboard export.
@@ -81,7 +107,7 @@ final class LogStore: Sendable {
             "Snap Diagnostic Log",
             "Exported: \(formatter.string(from: Date()))",
             "Entries: \(snapshot.count)",
-            String(repeating: "─", count: 72)
+            String(repeating: "─", count: 72),
         ]
 
         for entry in snapshot {

--- a/Sources/Snap/Diagnostics/LogStore.swift
+++ b/Sources/Snap/Diagnostics/LogStore.swift
@@ -107,7 +107,7 @@ final class LogStore: Sendable {
             "Snap Diagnostic Log",
             "Exported: \(formatter.string(from: Date()))",
             "Entries: \(snapshot.count)",
-            String(repeating: "─", count: 72),
+            String(repeating: "─", count: 72)
         ]
 
         for entry in snapshot {

--- a/Sources/Snap/Diagnostics/LogStore.swift
+++ b/Sources/Snap/Diagnostics/LogStore.swift
@@ -55,6 +55,7 @@ final class LogStore: Sendable {
     private let state: OSAllocatedUnfairLock<State>
 
     init(capacity: Int = 500) {
+        precondition(capacity > 0, "LogStore capacity must be at least 1")
         self.capacity = capacity
         self.state = OSAllocatedUnfairLock(initialState: State(capacity: capacity))
     }
@@ -83,7 +84,7 @@ final class LogStore: Sendable {
 
     func entries() -> [Entry] {
         state.withLock { st in
-            (0 ..< st.count).map { st.buffer[(st.head + $0) % st.capacity]! }
+            (0 ..< st.count).compactMap { st.buffer[(st.head + $0) % st.capacity] }
         }
     }
 

--- a/Sources/Snap/Diagnostics/SnapLogger.swift
+++ b/Sources/Snap/Diagnostics/SnapLogger.swift
@@ -1,0 +1,41 @@
+import Foundation
+import os
+
+/// Dual-write logger that sends messages to both `os.Logger` (system console)
+/// and the in-app `LogStore` ring buffer for diagnostics.
+///
+/// Drop-in replacement for `os.Logger` — same method names, takes `String`
+/// instead of `OSLogMessage` so interpolated values are captured without
+/// redaction.
+struct SnapLogger {
+    private let osLogger: Logger
+    private let category: String
+
+    init(category: String) {
+        self.osLogger = Logger(
+            subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
+            category: category
+        )
+        self.category = category
+    }
+
+    func info(_ message: String) {
+        osLogger.info("\(message, privacy: .public)")
+        LogStore.shared.append(level: .info, category: category, message: message)
+    }
+
+    func notice(_ message: String) {
+        osLogger.notice("\(message, privacy: .public)")
+        LogStore.shared.append(level: .notice, category: category, message: message)
+    }
+
+    func warning(_ message: String) {
+        osLogger.warning("\(message, privacy: .public)")
+        LogStore.shared.append(level: .warning, category: category, message: message)
+    }
+
+    func error(_ message: String) {
+        osLogger.error("\(message, privacy: .public)")
+        LogStore.shared.append(level: .error, category: category, message: message)
+    }
+}

--- a/Sources/Snap/Diagnostics/SnapLogger.swift
+++ b/Sources/Snap/Diagnostics/SnapLogger.swift
@@ -12,7 +12,7 @@ import os
 /// desktop utility — logged values (display IDs, UUIDs, paths) are the user's
 /// own hardware metadata, not sensitive data. The in-app LogStore and system
 /// log serve the same audience: the person sitting at the Mac.
-struct SnapLogger: Sendable {
+struct SnapLogger {
     private let osLogger: Logger
     private let category: String
     private let logStore: LogStore

--- a/Sources/Snap/Diagnostics/SnapLogger.swift
+++ b/Sources/Snap/Diagnostics/SnapLogger.swift
@@ -7,35 +7,42 @@ import os
 /// Drop-in replacement for `os.Logger` — same method names, takes `String`
 /// instead of `OSLogMessage` so interpolated values are captured without
 /// redaction.
-struct SnapLogger {
+///
+/// Messages are logged with `privacy: .public` because Snap is a user-local
+/// desktop utility — logged values (display IDs, UUIDs, paths) are the user's
+/// own hardware metadata, not sensitive data. The in-app LogStore and system
+/// log serve the same audience: the person sitting at the Mac.
+struct SnapLogger: Sendable {
     private let osLogger: Logger
     private let category: String
+    private let logStore: LogStore
 
-    init(category: String) {
+    init(category: String, logStore: LogStore) {
         self.osLogger = Logger(
             subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
             category: category
         )
         self.category = category
+        self.logStore = logStore
     }
 
     func info(_ message: String) {
         osLogger.info("\(message, privacy: .public)")
-        LogStore.shared.append(level: .info, category: category, message: message)
+        logStore.append(level: .info, category: category, message: message)
     }
 
     func notice(_ message: String) {
         osLogger.notice("\(message, privacy: .public)")
-        LogStore.shared.append(level: .notice, category: category, message: message)
+        logStore.append(level: .notice, category: category, message: message)
     }
 
     func warning(_ message: String) {
         osLogger.warning("\(message, privacy: .public)")
-        LogStore.shared.append(level: .warning, category: category, message: message)
+        logStore.append(level: .warning, category: category, message: message)
     }
 
     func error(_ message: String) {
         osLogger.error("\(message, privacy: .public)")
-        LogStore.shared.append(level: .error, category: category, message: message)
+        logStore.append(level: .error, category: category, message: message)
     }
 }

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 
 /// Persists display configurations keyed by display UUID.
 ///
@@ -9,10 +8,7 @@ final class DisplayConfigStore {
     private var configurations: [String: DisplayConfiguration] = [:]
     private let fileURL: URL
 
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
-        category: "DisplayConfigStore"
-    )
+    private static let logger = SnapLogger(category: "DisplayConfigStore")
 
     convenience init() {
         let appSupport: URL

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Persists display configurations keyed by display UUID.
 ///
@@ -10,13 +11,23 @@ final class DisplayConfigStore {
     private let logger: SnapLogger
 
     convenience init(logStore: LogStore = LogStore()) {
-        let appSupport = (try? FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )) ?? FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        let appSupport: URL
+        do {
+            appSupport = try FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        } catch {
+            // SnapLogger isn't available before self.init; use os.Logger for this unlikely fallback.
+            Logger(
+                subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
+                category: "DisplayConfigStore"
+            ).error("Failed to resolve Application Support directory: \(error.localizedDescription, privacy: .public)")
+            appSupport = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        }
         let snapDir = appSupport.appendingPathComponent("Snap", isDirectory: true)
         self.init(fileURL: snapDir.appendingPathComponent("displays.plist"), logStore: logStore)
     }

--- a/Sources/Snap/Display/DisplayConfigStore.swift
+++ b/Sources/Snap/Display/DisplayConfigStore.swift
@@ -7,35 +7,29 @@ import Foundation
 final class DisplayConfigStore {
     private var configurations: [String: DisplayConfiguration] = [:]
     private let fileURL: URL
+    private let logger: SnapLogger
 
-    private static let logger = SnapLogger(category: "DisplayConfigStore")
-
-    convenience init() {
-        let appSupport: URL
-        do {
-            appSupport = try FileManager.default.url(
-                for: .applicationSupportDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: true
-            )
-        } catch {
-            Self.logger.error("Failed to resolve Application Support directory: \(error)")
-            appSupport = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("Library/Application Support", isDirectory: true)
-        }
+    convenience init(logStore: LogStore = LogStore()) {
+        let appSupport = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
         let snapDir = appSupport.appendingPathComponent("Snap", isDirectory: true)
-        self.init(fileURL: snapDir.appendingPathComponent("displays.plist"))
+        self.init(fileURL: snapDir.appendingPathComponent("displays.plist"), logStore: logStore)
     }
 
-    init(fileURL: URL) {
+    init(fileURL: URL, logStore: LogStore = LogStore()) {
         self.fileURL = fileURL
+        self.logger = SnapLogger(category: "DisplayConfigStore", logStore: logStore)
 
         let parentDir = fileURL.deletingLastPathComponent()
         do {
             try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
         } catch {
-            Self.logger.error("Failed to create config directory: \(error)")
+            logger.error("Failed to create config directory: \(error)")
         }
 
         load()
@@ -78,7 +72,7 @@ final class DisplayConfigStore {
                 // No file yet — first launch, not an error
                 return
             }
-            Self.logger.error("Failed to read config file: \(error)")
+            logger.error("Failed to read config file: \(error)")
             return
         }
 
@@ -88,7 +82,7 @@ final class DisplayConfigStore {
                 from: data
             )
         } catch {
-            Self.logger.error("Failed to decode config file: \(error)")
+            logger.error("Failed to decode config file: \(error)")
         }
     }
 
@@ -99,7 +93,7 @@ final class DisplayConfigStore {
             let data = try encoder.encode(configurations)
             try data.write(to: fileURL, options: .atomic)
         } catch {
-            Self.logger.error("Failed to persist config file: \(error)")
+            logger.error("Failed to persist config file: \(error)")
         }
     }
 }

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -1,6 +1,5 @@
 import CoreGraphics
 import Foundation
-import os
 
 // MARK: - DisplayTransacting
 
@@ -57,10 +56,7 @@ struct SystemDisplayTransactor: DisplayTransacting {
 /// and safe to call from the main thread).
 @MainActor
 enum DisplayConfigurator {
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
-        category: "DisplayConfigurator"
-    )
+    private static let logger = SnapLogger(category: "DisplayConfigurator")
 
     /// Apply the given configuration to the external display.
     ///

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -96,6 +96,7 @@ enum DisplayConfigurator {
 
     // MARK: - Extend
 
+    // swiftlint:disable:next function_parameter_count
     private static func applyExtend(
         _ config: DisplayConfiguration,
         cfg: CGDisplayConfigRef,
@@ -157,6 +158,7 @@ enum DisplayConfigurator {
 
     // MARK: - Mirror
 
+    // swiftlint:disable:next function_parameter_count
     private static func applyMirror(
         _ config: DisplayConfiguration,
         cfg: CGDisplayConfigRef,

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -56,8 +56,6 @@ struct SystemDisplayTransactor: DisplayTransacting {
 /// and safe to call from the main thread).
 @MainActor
 enum DisplayConfigurator {
-    private static let logger = SnapLogger(category: "DisplayConfigurator")
-
     /// Apply the given configuration to the external display.
     ///
     /// Wraps all changes in `beginConfiguration` / `completeConfiguration` transactions
@@ -66,7 +64,8 @@ enum DisplayConfigurator {
         _ config: DisplayConfiguration,
         primaryID: CGDirectDisplayID,
         externalID: CGDirectDisplayID,
-        transactor: DisplayTransacting = SystemDisplayTransactor()
+        transactor: DisplayTransacting = SystemDisplayTransactor(),
+        logger: SnapLogger
     ) {
         guard let cfg = transactor.beginConfiguration() else {
             logger.error("beginConfiguration failed")
@@ -75,9 +74,9 @@ enum DisplayConfigurator {
 
         switch config.mode {
         case .extend:
-            applyExtend(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor)
+            applyExtend(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor, logger: logger)
         case .mirror:
-            applyMirror(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor)
+            applyMirror(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor, logger: logger)
         }
     }
 
@@ -88,7 +87,8 @@ enum DisplayConfigurator {
         cfg: CGDisplayConfigRef,
         primaryID: CGDirectDisplayID,
         externalID: CGDirectDisplayID,
-        transactor: DisplayTransacting
+        transactor: DisplayTransacting,
+        logger: SnapLogger
     ) {
         // Determine whether we need a separate unmirror transaction.
         // When mirrored, we must commit the unmirror first so that
@@ -148,7 +148,8 @@ enum DisplayConfigurator {
         cfg: CGDisplayConfigRef,
         primaryID: CGDirectDisplayID,
         externalID: CGDirectDisplayID,
-        transactor: DisplayTransacting
+        transactor: DisplayTransacting,
+        logger: SnapLogger
     ) {
         switch config.mirrorTarget {
         case .macBook:

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -74,9 +74,23 @@ enum DisplayConfigurator {
 
         switch config.mode {
         case .extend:
-            applyExtend(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor, logger: logger)
+            applyExtend(
+                config,
+                cfg: cfg,
+                primaryID: primaryID,
+                externalID: externalID,
+                transactor: transactor,
+                logger: logger
+            )
         case .mirror:
-            applyMirror(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor, logger: logger)
+            applyMirror(
+                config,
+                cfg: cfg,
+                primaryID: primaryID,
+                externalID: externalID,
+                transactor: transactor,
+                logger: logger
+            )
         }
     }
 

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -2,7 +2,6 @@ import AppKit
 import ColorSync
 import CoreGraphics
 import Foundation
-import os
 
 /// Delegate protocol for display connection events.
 @MainActor
@@ -27,10 +26,7 @@ protocol DisplayMonitorDelegate: AnyObject {
 final class DisplayMonitor: @unchecked Sendable {
     @MainActor weak var delegate: DisplayMonitorDelegate?
 
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
-        category: "DisplayMonitor"
-    )
+    private static let logger = SnapLogger(category: "DisplayMonitor")
 
     /// Tracks pending debounce tasks per display ID so rapid events are coalesced.
     @MainActor private var pendingEvents: [CGDirectDisplayID: Task<Void, Never>] = [:]

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -43,6 +43,15 @@ final class DisplayMonitor: @unchecked Sendable {
     /// Returns whether a display ID is currently online. Injectable for testing.
     private let isOnline: @Sendable (CGDirectDisplayID) -> Bool
 
+    /// Returns the persistent UUID string for a display ID. Injectable for testing.
+    private let displayUUIDProvider: @Sendable (CGDirectDisplayID) -> String
+
+    /// Returns the display bounds for a display ID. Injectable for testing.
+    private let displayBoundsProvider: @Sendable (CGDirectDisplayID) -> CGRect
+
+    /// Returns the human-readable name for a display ID. Injectable for testing.
+    private let displayNameProvider: @MainActor (CGDirectDisplayID) -> String
+
     /// The C callback for `CGDisplayRegisterReconfigurationCallback`.
     /// Bridges to the Swift instance via an `Unmanaged` pointer in `userInfo`.
     private static let reconfigurationCallback: CGDisplayReconfigurationCallBack = { displayID, flags, userInfo in
@@ -65,12 +74,35 @@ final class DisplayMonitor: @unchecked Sendable {
                 return false
             }
             return ids.contains(displayID)
+        },
+        displayUUID: @escaping @Sendable (CGDirectDisplayID) -> String = { displayID in
+            guard let unmanagedUUID = CGDisplayCreateUUIDFromDisplayID(displayID) else {
+                return "unknown-\(displayID)"
+            }
+            let cfUUID = unmanagedUUID.takeRetainedValue()
+            guard let cfString = CFUUIDCreateString(nil, cfUUID) else {
+                return "unknown-\(displayID)"
+            }
+            return cfString as String
+        },
+        displayBounds: @escaping @Sendable (CGDirectDisplayID) -> CGRect = { CGDisplayBounds($0) },
+        displayName: @escaping @MainActor (CGDirectDisplayID) -> String = { displayID in
+            for screen in NSScreen.screens {
+                let screenID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+                if screenID == displayID {
+                    return screen.localizedName
+                }
+            }
+            return "External Display"
         }
     ) {
         self.logger = SnapLogger(category: "DisplayMonitor", logStore: logStore)
         self.debounceInterval = debounceInterval
         self.isBuiltIn = isBuiltIn
         self.isOnline = isOnline
+        self.displayUUIDProvider = displayUUID
+        self.displayBoundsProvider = displayBounds
+        self.displayNameProvider = displayName
     }
 
     // MARK: - Monitoring lifecycle
@@ -146,7 +178,7 @@ final class DisplayMonitor: @unchecked Sendable {
         // The display might already be in a mirror set if macOS auto-mirrors on connect.
 
         let capturedUUID = displayUUID(for: displayID)
-        let bounds = CGDisplayBounds(displayID)
+        let bounds = displayBoundsProvider(displayID)
         let resolution = bounds.size
 
         logger.notice(
@@ -173,7 +205,7 @@ final class DisplayMonitor: @unchecked Sendable {
 
             // Re-read metadata post-debounce — values may have settled
             let name = monitor.displayName(for: displayID)
-            let settledBounds = CGDisplayBounds(displayID)
+            let settledBounds = monitor.displayBoundsProvider(displayID)
             monitor.delegate?.displayDidConnect(
                 id: displayID,
                 uuid: currentUUID,
@@ -209,28 +241,21 @@ final class DisplayMonitor: @unchecked Sendable {
 
     /// Returns a persistent UUID string for the given display.
     func displayUUID(for displayID: CGDirectDisplayID) -> String {
-        guard let unmanagedUUID = CGDisplayCreateUUIDFromDisplayID(displayID) else {
+        let uuid = displayUUIDProvider(displayID)
+        if uuid.hasPrefix("unknown-") {
             logger.warning("Could not create UUID for display \(displayID), using fallback")
-            return "unknown-\(displayID)"
         }
-        let cfUUID = unmanagedUUID.takeRetainedValue()
-        guard let cfString = CFUUIDCreateString(nil, cfUUID) else {
-            return "unknown-\(displayID)"
-        }
-        return cfString as String
+        return uuid
     }
 
     /// Returns the human-readable product name via NSScreen.
     @MainActor
     func displayName(for displayID: CGDirectDisplayID) -> String {
-        for screen in NSScreen.screens {
-            let screenID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
-            if screenID == displayID {
-                return screen.localizedName
-            }
+        let name = displayNameProvider(displayID)
+        if name == "External Display" {
+            logger.notice("No NSScreen match for display \(displayID), using fallback")
         }
-        logger.notice("No NSScreen match for display \(displayID), using fallback")
-        return "External Display"
+        return name
     }
 }
 

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -26,7 +26,7 @@ protocol DisplayMonitorDelegate: AnyObject {
 final class DisplayMonitor: @unchecked Sendable {
     @MainActor weak var delegate: DisplayMonitorDelegate?
 
-    private static let logger = SnapLogger(category: "DisplayMonitor")
+    private let logger: SnapLogger
 
     /// Tracks pending debounce tasks per display ID so rapid events are coalesced.
     @MainActor private var pendingEvents: [CGDirectDisplayID: Task<Void, Never>] = [:]
@@ -52,6 +52,7 @@ final class DisplayMonitor: @unchecked Sendable {
     }
 
     init(
+        logStore: LogStore = LogStore(),
         debounceInterval: Duration = .milliseconds(500),
         isBuiltIn: @escaping @Sendable (CGDirectDisplayID) -> Bool = { CGDisplayIsBuiltin($0) != 0 },
         isOnline: @escaping @Sendable (CGDirectDisplayID) -> Bool = { displayID in
@@ -66,6 +67,7 @@ final class DisplayMonitor: @unchecked Sendable {
             return ids.contains(displayID)
         }
     ) {
+        self.logger = SnapLogger(category: "DisplayMonitor", logStore: logStore)
         self.debounceInterval = debounceInterval
         self.isBuiltIn = isBuiltIn
         self.isOnline = isOnline
@@ -80,9 +82,9 @@ final class DisplayMonitor: @unchecked Sendable {
         let pointer = Unmanaged.passUnretained(self).toOpaque()
         let status = CGDisplayRegisterReconfigurationCallback(Self.reconfigurationCallback, pointer)
         if status != .success {
-            Self.logger.error("Failed to register display reconfiguration callback: \(status.rawValue)")
+            logger.error("Failed to register display reconfiguration callback: \(status.rawValue)")
         } else {
-            Self.logger.notice("Display monitoring started")
+            logger.notice("Display monitoring started")
         }
     }
 
@@ -93,7 +95,7 @@ final class DisplayMonitor: @unchecked Sendable {
         CGDisplayRemoveReconfigurationCallback(Self.reconfigurationCallback, pointer)
         isStopped = true
         cancelAllPendingEvents()
-        Self.logger.notice("Display monitoring stopped")
+        logger.notice("Display monitoring stopped")
     }
 
     /// Cancel all in-flight debounce tasks to prevent stale delegate calls.
@@ -114,7 +116,7 @@ final class DisplayMonitor: @unchecked Sendable {
 
     func handleReconfiguration(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
         // Log all events for debugging
-        Self.logger.notice(
+        logger.notice(
             // swiftformat:disable:next wrap
             // swiftlint:disable:next line_length
             "Reconfiguration event: display=\(displayID) flags=\(flags.rawValue) add=\(flags.contains(.addFlag)) builtin=\(CGDisplayIsBuiltin(displayID)) mirror=\(CGDisplayIsInMirrorSet(displayID))"
@@ -126,12 +128,12 @@ final class DisplayMonitor: @unchecked Sendable {
         // the display (e.g. mirror/unmirror transition) — not a physical disconnect.
         // Suppress both connect and disconnect to avoid re-applying config in a loop.
         if flags.contains(.removeFlag), flags.contains(.addFlag) {
-            Self.logger.notice("Display \(displayID) reconfigured (add+remove) — no action needed")
+            logger.notice("Display \(displayID) reconfigured (add+remove) — no action needed")
             return
         }
 
         if flags.contains(.removeFlag) {
-            Self.logger.notice("External display disconnected: \(displayID)")
+            logger.notice("External display disconnected: \(displayID)")
             dispatchDebounced(displayID: displayID) { monitor in
                 monitor.delegate?.displayDidDisconnect(id: displayID)
             }
@@ -147,7 +149,7 @@ final class DisplayMonitor: @unchecked Sendable {
         let bounds = CGDisplayBounds(displayID)
         let resolution = bounds.size
 
-        Self.logger.notice(
+        logger.notice(
             "External display connected: [\(capturedUUID)] \(Int(resolution.width))×\(Int(resolution.height))"
         )
 
@@ -156,14 +158,14 @@ final class DisplayMonitor: @unchecked Sendable {
             // Post-debounce validation: verify the display is still present and
             // hasn't been replaced by a different physical display reusing the ID.
             guard isOnline(displayID) else {
-                Self.logger.notice(
+                monitor.logger.notice(
                     "Display \(displayID) went offline during debounce — dropping connect event"
                 )
                 return
             }
             let currentUUID = monitor.displayUUID(for: displayID)
             guard currentUUID == capturedUUID else {
-                Self.logger.notice(
+                monitor.logger.notice(
                     "Display \(displayID) UUID changed during debounce (\(capturedUUID) → \(currentUUID)) — dropping"
                 )
                 return
@@ -208,7 +210,7 @@ final class DisplayMonitor: @unchecked Sendable {
     /// Returns a persistent UUID string for the given display.
     func displayUUID(for displayID: CGDirectDisplayID) -> String {
         guard let unmanagedUUID = CGDisplayCreateUUIDFromDisplayID(displayID) else {
-            Self.logger.warning("Could not create UUID for display \(displayID), using fallback")
+            logger.warning("Could not create UUID for display \(displayID), using fallback")
             return "unknown-\(displayID)"
         }
         let cfUUID = unmanagedUUID.takeRetainedValue()
@@ -227,7 +229,7 @@ final class DisplayMonitor: @unchecked Sendable {
                 return screen.localizedName
             }
         }
-        Self.logger.notice("No NSScreen match for display \(displayID), using fallback")
+        logger.notice("No NSScreen match for display \(displayID), using fallback")
         return "External Display"
     }
 }

--- a/Sources/Snap/UI/SettingsWindowController.swift
+++ b/Sources/Snap/UI/SettingsWindowController.swift
@@ -7,10 +7,12 @@ import SwiftUI
 final class SettingsWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private let configStore: DisplayConfigStore
+    private let logStore: LogStore
     private let updaterController: SPUStandardUpdaterController
 
-    init(configStore: DisplayConfigStore, updaterController: SPUStandardUpdaterController) {
+    init(configStore: DisplayConfigStore, logStore: LogStore, updaterController: SPUStandardUpdaterController) {
         self.configStore = configStore
+        self.logStore = logStore
         self.updaterController = updaterController
         super.init()
     }
@@ -24,6 +26,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
 
         let settingsView = SettingsView(
             configStore: configStore,
+            logStore: logStore,
             checkForUpdates: { [weak self] in
                 self?.updaterController.checkForUpdates(nil)
             }

--- a/Sources/Snap/UI/SettingsWindowController.swift
+++ b/Sources/Snap/UI/SettingsWindowController.swift
@@ -34,7 +34,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
 
         let hostingView = NSHostingView(rootView: settingsView)
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 520),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/Snap/UI/ToastWindowController.swift
+++ b/Sources/Snap/UI/ToastWindowController.swift
@@ -1,5 +1,4 @@
 import AppKit
-import os
 import UserNotifications
 
 /// Shows native macOS notifications for known-display auto-apply events.
@@ -9,10 +8,7 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
     private static let categoryID = "DISPLAY_APPLIED"
     nonisolated private static let changeActionID = "CHANGE_ACTION"
 
-    private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "au.steamedhams.snap",
-        category: "ToastWindowController"
-    )
+    private static let logger = SnapLogger(category: "ToastWindowController")
 
     override init() {
         super.init()

--- a/Sources/Snap/UI/ToastWindowController.swift
+++ b/Sources/Snap/UI/ToastWindowController.swift
@@ -8,9 +8,10 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
     private static let categoryID = "DISPLAY_APPLIED"
     nonisolated private static let changeActionID = "CHANGE_ACTION"
 
-    private static let logger = SnapLogger(category: "ToastWindowController")
+    private let logger: SnapLogger
 
-    override init() {
+    init(logStore: LogStore) {
+        self.logger = SnapLogger(category: "ToastWindowController", logStore: logStore)
         super.init()
         let center = UNUserNotificationCenter.current()
         center.delegate = self
@@ -27,11 +28,12 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
         )
         center.setNotificationCategories([category])
 
+        let log = logger
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error {
-                Self.logger.error("Notification auth error: \(error)")
+                log.error("Notification auth error: \(error)")
             }
-            Self.logger.notice("Notification permission granted: \(granted)")
+            log.notice("Notification permission granted: \(granted)")
         }
     }
 
@@ -56,9 +58,10 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
             trigger: nil
         )
 
+        let log = logger
         UNUserNotificationCenter.current().add(request) { error in
             if let error {
-                Self.logger.error("Failed to add notification: \(error)")
+                log.error("Failed to add notification: \(error)")
                 return
             }
 

--- a/Sources/Snap/UI/ToastWindowController.swift
+++ b/Sources/Snap/UI/ToastWindowController.swift
@@ -5,6 +5,7 @@ import UserNotifications
 @MainActor
 final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
     private var onChangeTapped: (() -> Void)?
+    private var autoDismissTask: Task<Void, Never>?
     private static let categoryID = "DISPLAY_APPLIED"
     nonisolated private static let changeActionID = "CHANGE_ACTION"
 
@@ -69,15 +70,20 @@ final class ToastWindowController: NSObject, UNUserNotificationCenterDelegate {
                 return
             }
 
-            Task { @MainActor in
-                try? await Task.sleep(for: .seconds(duration))
-                UNUserNotificationCenter.current()
-                    .removeDeliveredNotifications(withIdentifiers: [identifier])
+            Task { @MainActor [weak self] in
+                self?.autoDismissTask?.cancel()
+                self?.autoDismissTask = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(duration))
+                    UNUserNotificationCenter.current()
+                        .removeDeliveredNotifications(withIdentifiers: [identifier])
+                }
             }
         }
     }
 
     func dismiss() {
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
         UNUserNotificationCenter.current().removeAllDeliveredNotifications()
     }
 

--- a/Sources/Snap/Views/DiagnosticsView.swift
+++ b/Sources/Snap/Views/DiagnosticsView.swift
@@ -1,0 +1,197 @@
+import AppKit
+import SwiftUI
+
+/// In-app diagnostic log viewer. Shows the ring buffer contents with
+/// filtering by category and level, auto-refresh, and clipboard export.
+@MainActor
+struct DiagnosticsView: View {
+    let logStore: LogStore
+
+    @State private var entries: [LogStore.Entry] = []
+    @State private var selectedCategory: String?
+    @State private var minimumLevel: LogStore.Level = .info
+    @State private var refreshTask: Task<Void, Never>?
+
+    private var categories: [String] {
+        Array(Set(entries.map(\.category))).sorted()
+    }
+
+    private var filteredEntries: [LogStore.Entry] {
+        entries.filter { entry in
+            if let selected = selectedCategory, entry.category != selected {
+                return false
+            }
+            return entry.level >= minimumLevel
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            filterBar
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+
+            Divider()
+
+            if filteredEntries.isEmpty {
+                Spacer()
+                Text(entries.isEmpty ? "No log entries yet" : "No entries match filters")
+                    .foregroundStyle(.secondary)
+                Spacer()
+            } else {
+                logList
+            }
+
+            Divider()
+
+            statusBar
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+        }
+        .onAppear {
+            refresh()
+            startAutoRefresh()
+        }
+        .onDisappear {
+            refreshTask?.cancel()
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        HStack(spacing: 8) {
+            Picker("Category", selection: $selectedCategory) {
+                Text("All Categories").tag(String?.none)
+                ForEach(categories, id: \.self) { category in
+                    Text(category).tag(String?.some(category))
+                }
+            }
+            .fixedSize()
+
+            Picker("Level", selection: $minimumLevel) {
+                ForEach(LogStore.Level.allCases, id: \.self) { level in
+                    Text(level.rawValue.capitalized).tag(level)
+                }
+            }
+            .fixedSize()
+
+            Spacer()
+
+            Button {
+                let report = logStore.formattedReport()
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(report, forType: .string)
+            } label: {
+                Label("Copy", systemImage: "doc.on.clipboard")
+            }
+            .controlSize(.small)
+            .help("Copy full log to clipboard")
+
+            Button {
+                logStore.clear()
+                refresh()
+            } label: {
+                Label("Clear", systemImage: "trash")
+            }
+            .controlSize(.small)
+            .help("Clear all log entries")
+        }
+    }
+
+    // MARK: - Log List
+
+    private var logList: some View {
+        ScrollViewReader { proxy in
+            List(filteredEntries) { entry in
+                logEntryRow(entry)
+                    .id(entry.id)
+            }
+            .listStyle(.plain)
+            .font(.system(size: 11, design: .monospaced))
+            .onChange(of: filteredEntries.last?.id) { _, newID in
+                if let newID {
+                    withAnimation {
+                        proxy.scrollTo(newID, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private func logEntryRow(_ entry: LogStore.Entry) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text(formatTimestamp(entry.timestamp))
+                .foregroundStyle(.secondary)
+
+            Text(levelBadge(entry.level))
+                .foregroundStyle(levelColor(entry.level))
+                .frame(width: 32, alignment: .leading)
+
+            Text(entry.category)
+                .foregroundStyle(.secondary)
+                .frame(width: 110, alignment: .leading)
+
+            Text(entry.message)
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+        }
+    }
+
+    // MARK: - Status Bar
+
+    private var statusBar: some View {
+        HStack {
+            Text("\(filteredEntries.count) of \(entries.count) entries")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func refresh() {
+        entries = logStore.entries()
+    }
+
+    private func startAutoRefresh() {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [logStore] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { break }
+                entries = logStore.entries()
+            }
+        }
+    }
+
+    private static let timestampFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "HH:mm:ss.SSS"
+        return fmt
+    }()
+
+    private func formatTimestamp(_ date: Date) -> String {
+        Self.timestampFormatter.string(from: date)
+    }
+
+    private func levelBadge(_ level: LogStore.Level) -> String {
+        switch level {
+        case .info: "INFO"
+        case .notice: "NOTE"
+        case .warning: "WARN"
+        case .error: "ERR"
+        }
+    }
+
+    private func levelColor(_ level: LogStore.Level) -> Color {
+        switch level {
+        case .info: .secondary
+        case .notice: .primary
+        case .warning: .orange
+        case .error: .red
+        }
+    }
+}

--- a/Sources/Snap/Views/DiagnosticsView.swift
+++ b/Sources/Snap/Views/DiagnosticsView.swift
@@ -154,6 +154,10 @@ struct DiagnosticsView: View {
 
     private func refresh() {
         entries = logStore.entries()
+        if let selected = selectedCategory,
+           !entries.contains(where: { $0.category == selected }) {
+            selectedCategory = nil
+        }
     }
 
     private func startAutoRefresh() {
@@ -163,6 +167,10 @@ struct DiagnosticsView: View {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { break }
                 entries = logStore.entries()
+                if let selected = selectedCategory,
+                   !entries.contains(where: { $0.category == selected }) {
+                    selectedCategory = nil
+                }
             }
         }
     }

--- a/Sources/Snap/Views/DiagnosticsView.swift
+++ b/Sources/Snap/Views/DiagnosticsView.swift
@@ -10,7 +10,7 @@ struct DiagnosticsView: View {
     @State private var entries: [LogStore.Entry] = []
     @State private var selectedCategory: String?
     @State private var minimumLevel: LogStore.Level = .info
-    @State private var refreshTask: Task<Void, Never>?
+    @State private var lastGeneration: UInt64 = 0
 
     private var categories: [String] {
         Array(Set(entries.map(\.category))).sorted()
@@ -48,12 +48,17 @@ struct DiagnosticsView: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
         }
-        .onAppear {
+        .task {
             refresh()
-            startAutoRefresh()
-        }
-        .onDisappear {
-            refreshTask?.cancel()
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { break }
+                let gen = logStore.generation
+                if gen != lastGeneration {
+                    lastGeneration = gen
+                    refresh()
+                }
+            }
         }
     }
 
@@ -155,18 +160,6 @@ struct DiagnosticsView: View {
     private func refresh() {
         entries = logStore.entries()
         resetCategoryIfNeeded()
-    }
-
-    private func startAutoRefresh() {
-        refreshTask?.cancel()
-        refreshTask = Task { @MainActor [logStore] in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
-                guard !Task.isCancelled else { break }
-                entries = logStore.entries()
-                resetCategoryIfNeeded()
-            }
-        }
     }
 
     private func resetCategoryIfNeeded() {

--- a/Sources/Snap/Views/DiagnosticsView.swift
+++ b/Sources/Snap/Views/DiagnosticsView.swift
@@ -155,7 +155,8 @@ struct DiagnosticsView: View {
     private func refresh() {
         entries = logStore.entries()
         if let selected = selectedCategory,
-           !entries.contains(where: { $0.category == selected }) {
+           !entries.contains(where: { $0.category == selected })
+        {
             selectedCategory = nil
         }
     }
@@ -168,7 +169,8 @@ struct DiagnosticsView: View {
                 guard !Task.isCancelled else { break }
                 entries = logStore.entries()
                 if let selected = selectedCategory,
-                   !entries.contains(where: { $0.category == selected }) {
+                   !entries.contains(where: { $0.category == selected })
+                {
                     selectedCategory = nil
                 }
             }

--- a/Sources/Snap/Views/DiagnosticsView.swift
+++ b/Sources/Snap/Views/DiagnosticsView.swift
@@ -154,11 +154,7 @@ struct DiagnosticsView: View {
 
     private func refresh() {
         entries = logStore.entries()
-        if let selected = selectedCategory,
-           !entries.contains(where: { $0.category == selected })
-        {
-            selectedCategory = nil
-        }
+        resetCategoryIfNeeded()
     }
 
     private func startAutoRefresh() {
@@ -168,12 +164,15 @@ struct DiagnosticsView: View {
                 try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { break }
                 entries = logStore.entries()
-                if let selected = selectedCategory,
-                   !entries.contains(where: { $0.category == selected })
-                {
-                    selectedCategory = nil
-                }
+                resetCategoryIfNeeded()
             }
+        }
+    }
+
+    private func resetCategoryIfNeeded() {
+        guard let selected = selectedCategory else { return }
+        if !entries.contains(where: { $0.category == selected }) {
+            selectedCategory = nil
         }
     }
 

--- a/Sources/Snap/Views/SettingsView.swift
+++ b/Sources/Snap/Views/SettingsView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 @MainActor
 struct SettingsView: View {
     let configStore: DisplayConfigStore
+    let logStore: LogStore
     let checkForUpdates: () -> Void
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -25,11 +26,14 @@ struct SettingsView: View {
             displaysTab
                 .tabItem { Label("Displays", systemImage: "display") }
                 .tag(1)
+            DiagnosticsView(logStore: logStore)
+                .tabItem { Label("Diagnostics", systemImage: "stethoscope") }
+                .tag(2)
             aboutTab
                 .tabItem { Label("About", systemImage: "info.circle") }
-                .tag(2)
+                .tag(3)
         }
-        .frame(width: 460, height: 520)
+        .frame(width: 560, height: 520)
         .onAppear {
             entries = configStore.allEntries()
         }

--- a/Sources/Snap/Views/SettingsView.swift
+++ b/Sources/Snap/Views/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
     let logStore: LogStore
     let checkForUpdates: () -> Void
 
-    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var launchAtLogin = false
     @State private var showNotification = UserDefaults.standard.object(
         forKey: "showToastOnKnownDisplay"
     ) as? Bool ?? true
@@ -17,6 +17,10 @@ struct SettingsView: View {
     @State private var settingsWindowID: ObjectIdentifier?
     @State private var selectedTab = 0
     @State private var showDebugDetails = false
+
+    private var logger: SnapLogger {
+        SnapLogger(category: "SettingsView", logStore: logStore)
+    }
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -35,6 +39,7 @@ struct SettingsView: View {
         }
         .frame(width: 560, height: 520)
         .onAppear {
+            launchAtLogin = SMAppService.mainApp.status == .enabled
             entries = configStore.allEntries()
         }
         .background(
@@ -81,7 +86,7 @@ struct SettingsView: View {
                             try SMAppService.mainApp.unregister()
                         }
                     } catch {
-                        print("Launch at login error: \(error)")
+                        logger.error("Launch at login error: \(error)")
                         launchAtLogin = SMAppService.mainApp.status == .enabled
                     }
                 }

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -78,6 +78,7 @@ struct DisplayConfiguratorTests {
     private let externalID: CGDirectDisplayID = 2
     private let internalBounds = CGRect(x: 0, y: 0, width: 1440, height: 900)
     private let externalBounds = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+    private let logger = SnapLogger(category: "Test", logStore: LogStore())
 
     private func makeTransactor() -> MockDisplayTransactor {
         let mock = MockDisplayTransactor()
@@ -106,7 +107,7 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
@@ -120,7 +121,7 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalLeft)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
@@ -134,7 +135,7 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalAbove)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
@@ -149,7 +150,7 @@ struct DisplayConfiguratorTests {
         mock.mirrorSetDisplays.insert(externalID)
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.mirrorCalls.count == 1)
         let unmirror = mock.mirrorCalls[0]
@@ -164,7 +165,7 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .mirror, mirror: .macBook)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.mirrorCalls.count == 1)
         #expect(mock.mirrorCalls[0].display == externalID)
@@ -177,7 +178,7 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .mirror, mirror: .external)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.mirrorCalls.count == 1)
         #expect(mock.mirrorCalls[0].display == primaryID)
@@ -193,7 +194,7 @@ struct DisplayConfiguratorTests {
         mock.beginShouldSucceed = false
         let config = makeConfig(mode: .extend)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.beginCalled)
         #expect(mock.originCalls.isEmpty)
@@ -208,7 +209,7 @@ struct DisplayConfiguratorTests {
         mock.completeShouldSucceed = false
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.completeCalled)
         #expect(mock.originCalls.isEmpty, "Unmirror failed — positioning should be skipped")
@@ -219,7 +220,7 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.completeCalled)
     }
@@ -230,7 +231,7 @@ struct DisplayConfiguratorTests {
         // mirrorSetDisplays is empty — display is not mirrored
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
 
         #expect(mock.mirrorCalls.isEmpty, "Should not attempt unmirror when not in mirror set")
         #expect(mock.originCalls.count == 1, "Should still position the display")

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -107,7 +107,13 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
@@ -121,7 +127,13 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalLeft)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
@@ -135,7 +147,13 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalAbove)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.originCalls.count == 1)
         let call = mock.originCalls[0]
@@ -150,7 +168,13 @@ struct DisplayConfiguratorTests {
         mock.mirrorSetDisplays.insert(externalID)
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.mirrorCalls.count == 1)
         let unmirror = mock.mirrorCalls[0]
@@ -165,7 +189,13 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .mirror, mirror: .macBook)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.mirrorCalls.count == 1)
         #expect(mock.mirrorCalls[0].display == externalID)
@@ -178,7 +208,13 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .mirror, mirror: .external)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.mirrorCalls.count == 1)
         #expect(mock.mirrorCalls[0].display == primaryID)
@@ -194,7 +230,13 @@ struct DisplayConfiguratorTests {
         mock.beginShouldSucceed = false
         let config = makeConfig(mode: .extend)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.beginCalled)
         #expect(mock.originCalls.isEmpty)
@@ -209,7 +251,13 @@ struct DisplayConfiguratorTests {
         mock.completeShouldSucceed = false
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.completeCalled)
         #expect(mock.originCalls.isEmpty, "Unmirror failed — positioning should be skipped")
@@ -220,7 +268,13 @@ struct DisplayConfiguratorTests {
         let mock = makeTransactor()
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.completeCalled)
     }
@@ -231,7 +285,13 @@ struct DisplayConfiguratorTests {
         // mirrorSetDisplays is empty — display is not mirrored
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
-        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            transactor: mock,
+            logger: logger
+        )
 
         #expect(mock.mirrorCalls.isEmpty, "Should not attempt unmirror when not in mirror set")
         #expect(mock.originCalls.count == 1, "Should still position the display")

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -44,7 +44,10 @@ struct DisplayMonitorDebounceTests {
         let monitor = DisplayMonitor(
             debounceInterval: testDebounce,
             isBuiltIn: { $0 == CGMainDisplayID() },
-            isOnline: isOnline
+            isOnline: isOnline,
+            displayUUID: { "fake-uuid-\($0)" },
+            displayBounds: { _ in CGRect(x: 0, y: 0, width: 2560, height: 1440) },
+            displayName: { _ in "Fake Display" }
         )
         let delegate = MockDisplayMonitorDelegate()
         monitor.delegate = delegate
@@ -66,6 +69,9 @@ struct DisplayMonitorDebounceTests {
 
         #expect(delegate.connectCalls.count == 1)
         #expect(delegate.connectCalls.first?.id == fakeDisplayA)
+        #expect(delegate.connectCalls.first?.uuid == "fake-uuid-999")
+        #expect(delegate.connectCalls.first?.name == "Fake Display")
+        #expect(delegate.connectCalls.first?.resolution == CGSize(width: 2560, height: 1440))
     }
 
     @Test("Rapid connect events for same display coalesce into one")
@@ -134,7 +140,10 @@ struct DisplayMonitorDebounceTests {
         let monitor = DisplayMonitor(
             debounceInterval: testDebounce,
             isBuiltIn: { $0 == builtInID },
-            isOnline: { _ in true }
+            isOnline: { _ in true },
+            displayUUID: { "fake-uuid-\($0)" },
+            displayBounds: { _ in CGRect(x: 0, y: 0, width: 2560, height: 1440) },
+            displayName: { _ in "Fake Display" }
         )
         let delegate = MockDisplayMonitorDelegate()
         monitor.delegate = delegate

--- a/Tests/SnapTests/LogStoreTests.swift
+++ b/Tests/SnapTests/LogStoreTests.swift
@@ -1,0 +1,94 @@
+@testable import Snap
+import Testing
+
+struct LogStoreTests {
+    @Test("Appends entries and returns them in order")
+    func appendAndRetrieve() {
+        let store = LogStore(capacity: 10)
+        store.append(level: .info, category: "Test", message: "first")
+        store.append(level: .notice, category: "Test", message: "second")
+
+        let entries = store.entries()
+        #expect(entries.count == 2)
+        #expect(entries[0].message == "first")
+        #expect(entries[1].message == "second")
+        #expect(entries[0].id < entries[1].id)
+    }
+
+    @Test("Respects capacity and drops oldest entries")
+    func capacityEviction() {
+        let store = LogStore(capacity: 3)
+        store.append(level: .info, category: "A", message: "one")
+        store.append(level: .info, category: "A", message: "two")
+        store.append(level: .info, category: "A", message: "three")
+        store.append(level: .info, category: "A", message: "four")
+
+        let entries = store.entries()
+        #expect(entries.count == 3)
+        #expect(entries[0].message == "two")
+        #expect(entries[1].message == "three")
+        #expect(entries[2].message == "four")
+    }
+
+    @Test("Clear removes all entries")
+    func clearEntries() {
+        let store = LogStore(capacity: 10)
+        store.append(level: .warning, category: "X", message: "hello")
+        #expect(store.entries().count == 1)
+
+        store.clear()
+        #expect(store.entries().isEmpty)
+    }
+
+    @Test("Entries preserve level and category")
+    func entryMetadata() {
+        let store = LogStore(capacity: 10)
+        store.append(level: .error, category: "Network", message: "timeout")
+
+        let entry = store.entries().first
+        #expect(entry?.level == .error)
+        #expect(entry?.category == "Network")
+        #expect(entry?.message == "timeout")
+    }
+
+    @Test("IDs increment monotonically across clears")
+    func idMonotonicity() throws {
+        let store = LogStore(capacity: 10)
+        store.append(level: .info, category: "T", message: "a")
+        let idBeforeClear = try #require(store.entries().last).id
+
+        store.clear()
+        store.append(level: .info, category: "T", message: "b")
+        let idAfterClear = try #require(store.entries().last).id
+
+        #expect(idAfterClear > idBeforeClear)
+    }
+
+    @Test("Formatted report includes header and entries")
+    func formattedReport() {
+        let store = LogStore(capacity: 10)
+        store.append(level: .notice, category: "App", message: "started")
+        store.append(level: .error, category: "Display", message: "failed")
+
+        let report = store.formattedReport()
+        #expect(report.contains("Snap Diagnostic Log"))
+        #expect(report.contains("Entries: 2"))
+        #expect(report.contains("[notice] App: started"))
+        #expect(report.contains("[error] Display: failed"))
+    }
+
+    @Test("Formatted report returns placeholder when empty")
+    func formattedReportEmpty() {
+        let store = LogStore(capacity: 10)
+        let report = store.formattedReport()
+        #expect(report == "No diagnostic log entries.")
+    }
+
+    @Test("Level comparison ordering")
+    func levelOrdering() {
+        #expect(LogStore.Level.info < .notice)
+        #expect(LogStore.Level.notice < .warning)
+        #expect(LogStore.Level.warning < .error)
+        #expect(!(LogStore.Level.error < .info))
+    }
+}

--- a/docs/decisions/001-public-privacy-os-logger.md
+++ b/docs/decisions/001-public-privacy-os-logger.md
@@ -1,0 +1,26 @@
+---
+status: decided
+date: 2026-05-16
+---
+
+# Public Privacy on os.Logger Calls
+
+## Context
+
+Copilot code review flags `privacy: .public` on os.Logger string interpolation as a potential data exposure risk. Raised in PR #79 (diagnostics logging) across two review rounds.
+
+## Options Considered
+
+| Option | Reversibility | Effort | Trade-off |
+|--------|--------------|--------|-----------|
+| A: Use `.public` on all os.Logger calls | Easy — change to `.private` | None | Unredacted system log; matches in-app LogStore; readable in Console.app |
+| B: Use `.private` (default) for os.Logger, keep LogStore unredacted | Easy — change to `.public` | Low | System log redacted (useless for debugging); LogStore still readable |
+| C: Make privacy configurable per call | Easy — remove config | Medium | Over-engineered for a user-local utility with no sensitive data |
+
+## Decision
+
+Option A. Snap is a user-local desktop utility — logged values (display IDs, UUIDs, hardware metadata) belong to the person at the Mac. The system log and in-app LogStore serve the same audience. No credentials, personal info, or third-party data is ever logged.
+
+## Escape Hatch
+
+Change `privacy: .public` to `privacy: .private` in `SnapLogger.swift` (4 call sites). One-line change per site.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| # | Decision | Status | Date |
+|---|----------|--------|------|
+| 001 | [Public privacy on os.Logger calls](001-public-privacy-os-logger.md) | Decided | 2026-05-16 |

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,25 @@
+---
+status: decided           # decided | open | revisiting | superseded
+date: YYYY-MM-DD
+---
+
+# [Decision Title]
+
+## Context
+
+What prompted this decision.
+
+## Options Considered
+
+| Option | Reversibility | Effort | Trade-off |
+|--------|--------------|--------|-----------|
+| A: ... | ... | ... | ... |
+| B: ... | ... | ... | ... |
+
+## Decision
+
+What was chosen and why.
+
+## Escape Hatch
+
+How to reverse or change course if this turns out wrong.


### PR DESCRIPTION
## Summary

Adds an in-app diagnostic log viewer so display detection issues can be investigated without Console.app or `log stream`. Closes #76.

## Approach

**Ring buffer + dual-write logger + Diagnostics tab in Settings.**

### New files

| File | Purpose |
|------|---------|
| `Sources/Snap/Diagnostics/LogStore.swift` | Thread-safe ring buffer (500 entries, `OSAllocatedUnfairLock`) |
| `Sources/Snap/Diagnostics/SnapLogger.swift` | Dual-write logger: os.Logger + LogStore |
| `Sources/Snap/Views/DiagnosticsView.swift` | New Settings tab with filters, auto-scroll, copy, clear |
| `Tests/SnapTests/LogStoreTests.swift` | 8 unit tests for LogStore |

### Modified files

Replaced `os.Logger` → `SnapLogger` in 5 files (AppDelegate, DisplayMonitor, DisplayConfigurator, DisplayConfigStore, ToastWindowController). Wired `LogStore` through SettingsWindowController → SettingsView.

**Zero behavioral changes** to display detection, hardening, or notifications. All existing safety features preserved (phantom display guards, stale prompt dismissal, debounce, test-host detection).

## Testing

- 60/60 tests pass (including 8 new LogStore tests)
- SwiftFormat + SwiftLint clean
- Manual: launch app → Settings → Diagnostics tab to see live log entries
