### PR TITLE
fix: cancel pending debounce tasks on stopMonitoring()

### DIFF
--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -89,7 +89,19 @@ final class DisplayMonitor: @unchecked Sendable {
     func stopMonitoring() {
         let pointer = Unmanaged.passUnretained(self).toOpaque()
         CGDisplayRemoveReconfigurationCallback(Self.reconfigurationCallback, pointer)
+        Task { @MainActor [weak self] in
+            self?.cancelAllPendingEvents()
+        }
         Self.logger.notice("Display monitoring stopped")
+    }
+
+    /// Cancel all in-flight debounce tasks to prevent stale delegate calls.
+    @MainActor
+    private func cancelAllPendingEvents() {
+        for task in pendingEvents.values {
+            task.cancel()
+        }
+        pendingEvents.removeAll()
     }
 
     deinit {

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -35,6 +35,9 @@ final class DisplayMonitor: @unchecked Sendable {
     /// Tracks pending debounce tasks per display ID so rapid events are coalesced.
     @MainActor private var pendingEvents: [CGDirectDisplayID: Task<Void, Never>] = [:]
 
+    /// Set when monitoring stops; checked by in-flight debounce tasks to bail out.
+    @MainActor private var isStopped = false
+
     /// How long to wait for additional events before dispatching.
     private let debounceInterval: Duration
 
@@ -75,7 +78,9 @@ final class DisplayMonitor: @unchecked Sendable {
     // MARK: - Monitoring lifecycle
 
     /// Start listening for display configuration changes.
+    @MainActor
     func startMonitoring() {
+        isStopped = false
         let pointer = Unmanaged.passUnretained(self).toOpaque()
         let status = CGDisplayRegisterReconfigurationCallback(Self.reconfigurationCallback, pointer)
         if status != .success {
@@ -86,12 +91,12 @@ final class DisplayMonitor: @unchecked Sendable {
     }
 
     /// Stop listening for display configuration changes.
+    @MainActor
     func stopMonitoring() {
         let pointer = Unmanaged.passUnretained(self).toOpaque()
         CGDisplayRemoveReconfigurationCallback(Self.reconfigurationCallback, pointer)
-        Task { @MainActor [weak self] in
-            self?.cancelAllPendingEvents()
-        }
+        isStopped = true
+        cancelAllPendingEvents()
         Self.logger.notice("Display monitoring stopped")
     }
 
@@ -190,12 +195,12 @@ final class DisplayMonitor: @unchecked Sendable {
         action: @escaping @MainActor (DisplayMonitor) -> Void
     ) {
         Task { @MainActor [weak self] in
-            guard let self else { return }
+            guard let self, !self.isStopped else { return }
             self.pendingEvents[displayID]?.cancel()
             self.pendingEvents[displayID] = Task { @MainActor [weak self] in
                 guard let self else { return }
                 try? await Task.sleep(for: self.debounceInterval)
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled, !self.isStopped else { return }
                 self.pendingEvents.removeValue(forKey: displayID)
                 action(self)
             }

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -223,10 +223,10 @@ struct DisplayMonitorDebounceTests {
         let (monitor, delegate) = makeSUT()
 
         monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
-        monitor.stopMonitoring()
+        await monitor.stopMonitoring()
 
-        // Let the MainActor task that cancels pending events execute,
-        // then wait past the debounce interval.
+        // Cancellation is synchronous on @MainActor now;
+        // wait past the debounce interval to confirm nothing fires.
         try await Task.sleep(for: debounceWait)
 
         #expect(delegate.connectCalls.isEmpty, "Pending event should have been cancelled by stopMonitoring")

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -215,4 +215,20 @@ struct DisplayMonitorDebounceTests {
         #expect(delegate.disconnectCalls.count == 1)
         #expect(delegate.connectCalls.isEmpty)
     }
+
+    // MARK: - Stop monitoring
+
+    @Test("stopMonitoring cancels pending debounce tasks")
+    func stopCancelsPendingEvents() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+        monitor.stopMonitoring()
+
+        // Let the MainActor task that cancels pending events execute,
+        // then wait past the debounce interval.
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.isEmpty, "Pending event should have been cancelled by stopMonitoring")
+    }
 }


### PR DESCRIPTION
## Problem

stopMonitoring() removed the CGDisplay callback but left in-flight debounce tasks in pendingEvents that could still fire and call the delegate after monitoring was stopped.

## Fix

Added cancelAllPendingEvents() — dispatched via @MainActor — that cancels and clears all pending debounce tasks when stopMonitoring() is called.

## Test

New test: stopCancelsPendingEvents — fires a connect event, immediately calls stopMonitoring(), then verifies the delegate was never called.

Addresses unresolved review feedback from #78.