### PR TITLE
fix: treat reconfiguration events (removeFlag + addFlag) as connect, not disconnect

### DIFF
--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -112,7 +112,7 @@ final class DisplayMonitor: @unchecked Sendable {
         // When both removeFlag and addFlag are present, macOS is reconfiguring
         // the display (e.g. mirror/unmirror transition) — not a physical disconnect.
         // Only treat as disconnect when removeFlag is set WITHOUT addFlag.
-        if flags.contains(.removeFlag) && !flags.contains(.addFlag) {
+        if flags.contains(.removeFlag), !flags.contains(.addFlag) {
             Self.logger.notice("External display disconnected: \(displayID)")
             dispatchDebounced(displayID: displayID) { monitor in
                 monitor.delegate?.displayDidDisconnect(id: displayID)

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -111,8 +111,13 @@ final class DisplayMonitor: @unchecked Sendable {
 
         // When both removeFlag and addFlag are present, macOS is reconfiguring
         // the display (e.g. mirror/unmirror transition) — not a physical disconnect.
-        // Only treat as disconnect when removeFlag is set WITHOUT addFlag.
-        if flags.contains(.removeFlag), !flags.contains(.addFlag) {
+        // Suppress both connect and disconnect to avoid re-applying config in a loop.
+        if flags.contains(.removeFlag), flags.contains(.addFlag) {
+            Self.logger.notice("Display \(displayID) reconfigured (add+remove) — no action needed")
+            return
+        }
+
+        if flags.contains(.removeFlag) {
             Self.logger.notice("External display disconnected: \(displayID)")
             dispatchDebounced(displayID: displayID) { monitor in
                 monitor.delegate?.displayDidDisconnect(id: displayID)

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -109,7 +109,10 @@ final class DisplayMonitor: @unchecked Sendable {
 
         guard !isBuiltIn(displayID) else { return }
 
-        if flags.contains(.removeFlag) {
+        // When both removeFlag and addFlag are present, macOS is reconfiguring
+        // the display (e.g. mirror/unmirror transition) — not a physical disconnect.
+        // Only treat as disconnect when removeFlag is set WITHOUT addFlag.
+        if flags.contains(.removeFlag) && !flags.contains(.addFlag) {
             Self.logger.notice("External display disconnected: \(displayID)")
             dispatchDebounced(displayID: displayID) { monitor in
                 monitor.delegate?.displayDidDisconnect(id: displayID)

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -187,8 +187,8 @@ struct DisplayMonitorDebounceTests {
 
     // MARK: - Reconfiguration (add + remove)
 
-    @Test("Reconfiguration with both add and remove flags treats as connect, not disconnect")
-    func reconfigurationTreatedAsConnect() async throws {
+    @Test("Reconfiguration with both add and remove flags is a no-op")
+    func reconfigurationIsNoOp() async throws {
         let (monitor, delegate) = makeSUT()
 
         // macOS sends both flags during mirror/unmirror transitions
@@ -200,7 +200,7 @@ struct DisplayMonitorDebounceTests {
 
         try await Task.sleep(for: debounceWait)
 
-        #expect(delegate.connectCalls.count == 1, "Should treat as connect")
+        #expect(delegate.connectCalls.isEmpty, "Should NOT treat as connect")
         #expect(delegate.disconnectCalls.isEmpty, "Should NOT treat as disconnect")
     }
 

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -184,4 +184,35 @@ struct DisplayMonitorDebounceTests {
 
         #expect(delegate.disconnectCalls.count == 1, "Disconnect should fire regardless of online status")
     }
+
+    // MARK: - Reconfiguration (add + remove)
+
+    @Test("Reconfiguration with both add and remove flags treats as connect, not disconnect")
+    func reconfigurationTreatedAsConnect() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        // macOS sends both flags during mirror/unmirror transitions
+        let combined = CGDisplayChangeSummaryFlags(
+            rawValue: CGDisplayChangeSummaryFlags.addFlag.rawValue
+                | CGDisplayChangeSummaryFlags.removeFlag.rawValue
+        )
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: combined)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.count == 1, "Should treat as connect")
+        #expect(delegate.disconnectCalls.isEmpty, "Should NOT treat as disconnect")
+    }
+
+    @Test("Remove-only flag still triggers disconnect")
+    func removeOnlyStillDisconnects() async throws {
+        let (monitor, delegate) = makeSUT()
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .removeFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.disconnectCalls.count == 1)
+        #expect(delegate.connectCalls.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #82 — Snap falsely reported "No display connected" after applying its own mirror/extend configuration.

## Root cause

When Snap applies a display config, macOS fires a reconfiguration callback with **both** `removeFlag` and `addFlag` set (e.g. `flags=4926`). This means "old config removed, new config applied" — a reconfigure, not a physical disconnect. The previous code checked `removeFlag` first and treated it as a disconnect.

## Changes

### `DisplayMonitor.swift`
- Changed the `removeFlag` guard to only trigger disconnect when `addFlag` is **not** also present
- Added a comment explaining why

### `DisplayMonitorTests.swift`
- Added test: reconfiguration with both add+remove flags treats as connect
- Added test: remove-only flag still correctly triggers disconnect

## Testing

- All 54 tests pass
- Verified with live Dell P3421W in mirror mode — logs confirm the reconfiguration event is now handled correctly