### PR TITLE
fix: split extend into two CGDisplay transactions for correct post-unmirror bounds

### DIFF
--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -74,8 +74,20 @@ enum DisplayConfigurator {
 
         switch config.mode {
         case .extend:
-            // Always unmirror first (handles mirror → extend transition)
+            // Transaction 1: unmirror (idempotent if not mirrored).
+            // Must commit before reading bounds so they reflect the
+            // independent (non-mirrored) display geometry.
             transactor.configureMirror(cfg, display: externalID, primary: kCGNullDirectDisplay)
+            if !transactor.completeConfiguration(cfg) {
+                logger.error("completeConfiguration failed (unmirror)")
+                return
+            }
+
+            // Transaction 2: position using settled post-unmirror bounds
+            guard let positionCfg = transactor.beginConfiguration() else {
+                logger.error("beginConfiguration failed (position)")
+                return
+            }
 
             let internalBounds = transactor.displayBounds(primaryID)
             let externalBounds = transactor.displayBounds(externalID)
@@ -97,8 +109,14 @@ enum DisplayConfigurator {
                 )
             }
 
-            transactor.configureOrigin(cfg, display: externalID, x: Int32(origin.x), y: Int32(origin.y))
+            transactor.configureOrigin(positionCfg, display: externalID, x: Int32(origin.x), y: Int32(origin.y))
             logger.info("Applying extend preset: \(config.extendPreset.rawValue)")
+
+            if transactor.completeConfiguration(positionCfg) {
+                logger.info("Display configuration applied successfully")
+            } else {
+                logger.error("completeConfiguration failed")
+            }
 
         case .mirror:
             switch config.mirrorTarget {
@@ -108,12 +126,12 @@ enum DisplayConfigurator {
                 transactor.configureMirror(cfg, display: primaryID, primary: externalID)
             }
             logger.info("Applying mirror target: \(config.mirrorTarget.rawValue)")
-        }
 
-        if transactor.completeConfiguration(cfg) {
-            logger.info("Display configuration applied successfully")
-        } else {
-            logger.error("completeConfiguration failed")
+            if transactor.completeConfiguration(cfg) {
+                logger.info("Display configuration applied successfully")
+            } else {
+                logger.error("completeConfiguration failed")
+            }
         }
     }
 }

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -59,7 +59,7 @@ enum DisplayConfigurator {
 
     /// Apply the given configuration to the external display.
     ///
-    /// Wraps all changes in a `beginConfiguration` / `completeConfiguration` transaction
+    /// Wraps all changes in `beginConfiguration` / `completeConfiguration` transactions
     /// driven by the provided `transactor`. The default uses real CGDisplay APIs.
     static func apply(
         _ config: DisplayConfiguration,
@@ -74,64 +74,87 @@ enum DisplayConfigurator {
 
         switch config.mode {
         case .extend:
-            // Transaction 1: unmirror (idempotent if not mirrored).
-            // Must commit before reading bounds so they reflect the
-            // independent (non-mirrored) display geometry.
-            transactor.configureMirror(cfg, display: externalID, primary: kCGNullDirectDisplay)
-            if !transactor.completeConfiguration(cfg) {
-                logger.error("completeConfiguration failed (unmirror)")
-                return
-            }
-
-            // Transaction 2: position using settled post-unmirror bounds
-            guard let positionCfg = transactor.beginConfiguration() else {
-                logger.error("beginConfiguration failed (position)")
-                return
-            }
-
-            let internalBounds = transactor.displayBounds(primaryID)
-            let externalBounds = transactor.displayBounds(externalID)
-            let origin = switch config.extendPreset {
-            case .externalRight:
-                CGPoint(
-                    x: internalBounds.maxX,
-                    y: internalBounds.midY - externalBounds.height / 2
-                )
-            case .externalLeft:
-                CGPoint(
-                    x: internalBounds.minX - externalBounds.width,
-                    y: internalBounds.midY - externalBounds.height / 2
-                )
-            case .externalAbove:
-                CGPoint(
-                    x: internalBounds.midX - externalBounds.width / 2,
-                    y: internalBounds.minY - externalBounds.height
-                )
-            }
-
-            transactor.configureOrigin(positionCfg, display: externalID, x: Int32(origin.x), y: Int32(origin.y))
-            logger.info("Applying extend preset: \(config.extendPreset.rawValue)")
-
-            if transactor.completeConfiguration(positionCfg) {
-                logger.info("Display configuration applied successfully")
-            } else {
-                logger.error("completeConfiguration failed")
-            }
-
+            applyExtend(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor)
         case .mirror:
-            switch config.mirrorTarget {
-            case .macBook:
-                transactor.configureMirror(cfg, display: externalID, primary: primaryID)
-            case .external:
-                transactor.configureMirror(cfg, display: primaryID, primary: externalID)
-            }
-            logger.info("Applying mirror target: \(config.mirrorTarget.rawValue)")
+            applyMirror(config, cfg: cfg, primaryID: primaryID, externalID: externalID, transactor: transactor)
+        }
+    }
 
-            if transactor.completeConfiguration(cfg) {
-                logger.info("Display configuration applied successfully")
-            } else {
-                logger.error("completeConfiguration failed")
-            }
+    // MARK: - Extend
+
+    private static func applyExtend(
+        _ config: DisplayConfiguration,
+        cfg: CGDisplayConfigRef,
+        primaryID: CGDirectDisplayID,
+        externalID: CGDirectDisplayID,
+        transactor: DisplayTransacting
+    ) {
+        // Transaction 1: unmirror (idempotent if not mirrored).
+        // Must commit before reading bounds so they reflect the
+        // independent (non-mirrored) display geometry.
+        transactor.configureMirror(cfg, display: externalID, primary: kCGNullDirectDisplay)
+        if !transactor.completeConfiguration(cfg) {
+            logger.error("completeConfiguration failed (unmirror)")
+            return
+        }
+
+        // Transaction 2: position using settled post-unmirror bounds
+        guard let positionCfg = transactor.beginConfiguration() else {
+            logger.error("beginConfiguration failed (position)")
+            return
+        }
+
+        let internalBounds = transactor.displayBounds(primaryID)
+        let externalBounds = transactor.displayBounds(externalID)
+        let origin = switch config.extendPreset {
+        case .externalRight:
+            CGPoint(
+                x: internalBounds.maxX,
+                y: internalBounds.midY - externalBounds.height / 2
+            )
+        case .externalLeft:
+            CGPoint(
+                x: internalBounds.minX - externalBounds.width,
+                y: internalBounds.midY - externalBounds.height / 2
+            )
+        case .externalAbove:
+            CGPoint(
+                x: internalBounds.midX - externalBounds.width / 2,
+                y: internalBounds.minY - externalBounds.height
+            )
+        }
+
+        transactor.configureOrigin(positionCfg, display: externalID, x: Int32(origin.x), y: Int32(origin.y))
+        logger.info("Applying extend preset: \(config.extendPreset.rawValue)")
+
+        if transactor.completeConfiguration(positionCfg) {
+            logger.info("Display configuration applied successfully")
+        } else {
+            logger.error("completeConfiguration failed")
+        }
+    }
+
+    // MARK: - Mirror
+
+    private static func applyMirror(
+        _ config: DisplayConfiguration,
+        cfg: CGDisplayConfigRef,
+        primaryID: CGDirectDisplayID,
+        externalID: CGDirectDisplayID,
+        transactor: DisplayTransacting
+    ) {
+        switch config.mirrorTarget {
+        case .macBook:
+            transactor.configureMirror(cfg, display: externalID, primary: primaryID)
+        case .external:
+            transactor.configureMirror(cfg, display: primaryID, primary: externalID)
+        }
+        logger.info("Applying mirror target: \(config.mirrorTarget.rawValue)")
+
+        if transactor.completeConfiguration(cfg) {
+            logger.info("Display configuration applied successfully")
+        } else {
+            logger.error("completeConfiguration failed")
         }
     }
 }

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -195,7 +195,7 @@ struct DisplayConfiguratorTests {
         #expect(!mock.completeCalled)
     }
 
-    @Test("Complete failure still calls complete (logs error)")
+    @Test("Complete failure aborts extend before positioning")
     func completeFailure() {
         let mock = makeTransactor()
         mock.completeShouldSucceed = false
@@ -204,7 +204,7 @@ struct DisplayConfiguratorTests {
         DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
 
         #expect(mock.completeCalled)
-        #expect(mock.originCalls.count == 1)
+        #expect(mock.originCalls.isEmpty, "Unmirror failed — positioning should be skipped")
     }
 
     @Test("Successful apply calls complete")


### PR DESCRIPTION
## Summary

Fixes #84 — External Above preset was left-aligned instead of centred after mirror → extend transition.

## Root cause

`DisplayConfigurator.apply()` ran unmirror + bounds read + positioning in a single uncommitted CGDisplay transaction. `CGDisplayBounds` returned stale mirrored geometry, producing incorrect centering. This was masked before #83 because the false-disconnect bug caused a second apply with correct bounds.

## Changes

### `DisplayConfigurator.swift`
- Split extend mode into two transactions: unmirror+commit first, then read settled bounds and position in a second transaction
- Each mode (extend/mirror) now owns its complete lifecycle

### `DisplayConfiguratorTests.swift`
- Updated `completeFailure` test: if unmirror complete fails, positioning is correctly skipped (was previously expected to still position)

## Testing

All 54 tests pass. The alignment fix itself needs hardware verification — please test with External Above preset after mirror mode.