### PR TITLE
fix: skip unmirror transaction when display is already unmirrored

### DIFF
--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -13,6 +13,7 @@ protocol DisplayTransacting {
     func configureMirror(_ configRef: CGDisplayConfigRef, display: CGDirectDisplayID, primary: CGDirectDisplayID)
     func completeConfiguration(_ configRef: CGDisplayConfigRef) -> Bool
     func displayBounds(_ display: CGDirectDisplayID) -> CGRect
+    func isInMirrorSet(_ display: CGDirectDisplayID) -> Bool
 }
 
 // MARK: - SystemDisplayTransactor
@@ -41,6 +42,10 @@ struct SystemDisplayTransactor: DisplayTransacting {
 
     func displayBounds(_ display: CGDirectDisplayID) -> CGRect {
         CGDisplayBounds(display)
+    }
+
+    func isInMirrorSet(_ display: CGDirectDisplayID) -> Bool {
+        CGDisplayIsInMirrorSet(display) != 0
     }
 }
 
@@ -89,19 +94,25 @@ enum DisplayConfigurator {
         externalID: CGDirectDisplayID,
         transactor: DisplayTransacting
     ) {
-        // Transaction 1: unmirror (idempotent if not mirrored).
-        // Must commit before reading bounds so they reflect the
-        // independent (non-mirrored) display geometry.
-        transactor.configureMirror(cfg, display: externalID, primary: kCGNullDirectDisplay)
-        if !transactor.completeConfiguration(cfg) {
-            logger.error("completeConfiguration failed (unmirror)")
-            return
-        }
-
-        // Transaction 2: position using settled post-unmirror bounds
-        guard let positionCfg = transactor.beginConfiguration() else {
-            logger.error("beginConfiguration failed (position)")
-            return
+        // Determine whether we need a separate unmirror transaction.
+        // When mirrored, we must commit the unmirror first so that
+        // CGDisplayBounds returns the independent (non-mirrored) geometry.
+        // When already unmirrored, skip straight to positioning using
+        // the transaction started by apply(). (Fixes #86)
+        let positionCfg: CGDisplayConfigRef
+        if transactor.isInMirrorSet(externalID) {
+            transactor.configureMirror(cfg, display: externalID, primary: kCGNullDirectDisplay)
+            if !transactor.completeConfiguration(cfg) {
+                logger.error("completeConfiguration failed (unmirror)")
+                return
+            }
+            guard let newCfg = transactor.beginConfiguration() else {
+                logger.error("beginConfiguration failed (position)")
+                return
+            }
+            positionCfg = newCfg
+        } else {
+            positionCfg = cfg
         }
 
         let internalBounds = transactor.displayBounds(primaryID)
@@ -130,7 +141,7 @@ enum DisplayConfigurator {
         if transactor.completeConfiguration(positionCfg) {
             logger.info("Display configuration applied successfully")
         } else {
-            logger.error("completeConfiguration failed")
+            logger.error("completeConfiguration failed (position)")
         }
     }
 

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -31,6 +31,7 @@ final class MockDisplayTransactor: DisplayTransacting {
     var completeCalled = false
 
     var boundsMap: [CGDirectDisplayID: CGRect] = [:]
+    var mirrorSetDisplays: Set<CGDirectDisplayID> = []
 
     init() {
         dummyRaw = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
@@ -62,6 +63,10 @@ final class MockDisplayTransactor: DisplayTransacting {
     func displayBounds(_ display: CGDirectDisplayID) -> CGRect {
         boundsCalls.append(display)
         return boundsMap[display] ?? .zero
+    }
+
+    func isInMirrorSet(_ display: CGDirectDisplayID) -> Bool {
+        mirrorSetDisplays.contains(display)
     }
 }
 
@@ -138,9 +143,10 @@ struct DisplayConfiguratorTests {
         #expect(call.y == -1440) // 0 - 1440
     }
 
-    @Test("Extend always unmirrors first before positioning")
+    @Test("Extend unmirrors first when display is in mirror set")
     func extendUnmirrorsFirst() {
         let mock = makeTransactor()
+        mock.mirrorSetDisplays.insert(externalID)
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
         DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
@@ -195,9 +201,10 @@ struct DisplayConfiguratorTests {
         #expect(!mock.completeCalled)
     }
 
-    @Test("Complete failure aborts extend before positioning")
+    @Test("Unmirror complete failure aborts extend before positioning")
     func completeFailure() {
         let mock = makeTransactor()
+        mock.mirrorSetDisplays.insert(externalID)
         mock.completeShouldSucceed = false
         let config = makeConfig(mode: .extend, preset: .externalRight)
 
@@ -215,5 +222,21 @@ struct DisplayConfiguratorTests {
         DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
 
         #expect(mock.completeCalled)
+    }
+
+    @Test("Extend skips unmirror when display is not in mirror set (#86)")
+    func extendSkipsUnmirrorWhenNotMirrored() {
+        let mock = makeTransactor()
+        // mirrorSetDisplays is empty — display is not mirrored
+        let config = makeConfig(mode: .extend, preset: .externalRight)
+
+        DisplayConfigurator.apply(config, primaryID: primaryID, externalID: externalID, transactor: mock)
+
+        #expect(mock.mirrorCalls.isEmpty, "Should not attempt unmirror when not in mirror set")
+        #expect(mock.originCalls.count == 1, "Should still position the display")
+        let call = mock.originCalls[0]
+        #expect(call.display == externalID)
+        #expect(call.x == 1440)
+        #expect(call.y == -270)
     }
 }


### PR DESCRIPTION
Closes #86

## Problem

When re-applying an extend config to a display that is already unmirrored (e.g. user changes a setting after initial connect), `CGCompleteDisplayConfiguration` rejects the no-op unmirror transaction. This caused `applyExtend` to bail out before the positioning transaction ran, leaving the display at macOS's default position.

**Evidence from logs:**
```
11:01:26.723 E  [DisplayConfigurator] completeConfiguration failed (unmirror)
11:01:26.733 Df [AppDelegate] Saved config for <display> (auto-apply: true)
```

## Fix

Guard the unmirror transaction with `isInMirrorSet`:
- **Mirrored:** unmirror → commit → new transaction → position → commit (same as before)
- **Not mirrored:** skip unmirror, reuse existing transaction → position → commit

Added `isInMirrorSet` to `DisplayTransacting` protocol for testability.

## Tests

- Updated `extendUnmirrorsFirst` and `completeFailure` to explicitly set mirrored state
- Added regression test: "Extend skips unmirror when display is not in mirror set (#86)"
- All 55 tests pass