### PR TITLE
Fix stale display bounds after unmirror causing wrong arrangement

### DIFF
--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -165,7 +165,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID, logger: logger)
+        DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID, externalResolution: resolution, logger: logger)
 
         // Save the config so the display appears in Settings.
         // rememberThisDisplay controls whether to auto-apply silently next time.
@@ -287,7 +287,7 @@ extension AppDelegate: DisplayMonitorDelegate {
 
         if let savedConfig = configStore.configuration(for: uuid), savedConfig.rememberThisDisplay {
             // Known display with auto-apply — apply silently
-            DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id, logger: logger)
+            DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id, externalResolution: resolution, logger: logger)
 
             // Update lastConnected timestamp
             var updatedConfig = savedConfig

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -165,7 +165,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        DisplayConfigurator.apply(config, primaryID: CGMainDisplayID(), externalID: displayID, externalResolution: resolution, logger: logger)
+        DisplayConfigurator.apply(
+            config,
+            primaryID: CGMainDisplayID(),
+            externalID: displayID,
+            externalResolution: resolution,
+            logger: logger
+        )
 
         // Save the config so the display appears in Settings.
         // rememberThisDisplay controls whether to auto-apply silently next time.
@@ -287,7 +293,13 @@ extension AppDelegate: DisplayMonitorDelegate {
 
         if let savedConfig = configStore.configuration(for: uuid), savedConfig.rememberThisDisplay {
             // Known display with auto-apply — apply silently
-            DisplayConfigurator.apply(savedConfig, primaryID: CGMainDisplayID(), externalID: id, externalResolution: resolution, logger: logger)
+            DisplayConfigurator.apply(
+                savedConfig,
+                primaryID: CGMainDisplayID(),
+                externalID: id,
+                externalResolution: resolution,
+                logger: logger
+            )
 
             // Update lastConnected timestamp
             var updatedConfig = savedConfig

--- a/Sources/Snap/Display/DisplayConfigurator.swift
+++ b/Sources/Snap/Display/DisplayConfigurator.swift
@@ -60,10 +60,15 @@ enum DisplayConfigurator {
     ///
     /// Wraps all changes in `beginConfiguration` / `completeConfiguration` transactions
     /// driven by the provided `transactor`. The default uses real CGDisplay APIs.
+    ///
+    /// - Parameter externalResolution: The known resolution of the external display.
+    ///   Used instead of reading `CGDisplayBounds` for the external display, which can
+    ///   return stale values immediately after unmirror commits.
     static func apply(
         _ config: DisplayConfiguration,
         primaryID: CGDirectDisplayID,
         externalID: CGDirectDisplayID,
+        externalResolution: CGSize,
         transactor: DisplayTransacting = SystemDisplayTransactor(),
         logger: SnapLogger
     ) {
@@ -79,6 +84,7 @@ enum DisplayConfigurator {
                 cfg: cfg,
                 primaryID: primaryID,
                 externalID: externalID,
+                externalResolution: externalResolution,
                 transactor: transactor,
                 logger: logger
             )
@@ -102,6 +108,7 @@ enum DisplayConfigurator {
         cfg: CGDisplayConfigRef,
         primaryID: CGDirectDisplayID,
         externalID: CGDirectDisplayID,
+        externalResolution: CGSize,
         transactor: DisplayTransacting,
         logger: SnapLogger
     ) {
@@ -127,7 +134,10 @@ enum DisplayConfigurator {
         }
 
         let internalBounds = transactor.displayBounds(primaryID)
-        let externalBounds = transactor.displayBounds(externalID)
+        // Use the caller-supplied resolution instead of CGDisplayBounds for the
+        // external display. After an unmirror commit, CGDisplayBounds can return
+        // stale (mirrored) geometry before macOS finishes settling.
+        let externalBounds = CGRect(origin: .zero, size: externalResolution)
         let origin = switch config.extendPreset {
         case .externalRight:
             CGPoint(

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -78,6 +78,7 @@ struct DisplayConfiguratorTests {
     private let externalID: CGDirectDisplayID = 2
     private let internalBounds = CGRect(x: 0, y: 0, width: 1440, height: 900)
     private let externalBounds = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+    private var externalResolution: CGSize { externalBounds.size }
     private let logger = SnapLogger(category: "Test", logStore: LogStore())
 
     private func makeTransactor() -> MockDisplayTransactor {
@@ -111,6 +112,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -131,6 +133,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -151,6 +154,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -172,6 +176,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -193,6 +198,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -212,6 +218,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -234,6 +241,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -255,6 +263,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -272,6 +281,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -289,6 +299,7 @@ struct DisplayConfiguratorTests {
             config,
             primaryID: primaryID,
             externalID: externalID,
+            externalResolution: externalResolution,
             transactor: mock,
             logger: logger
         )
@@ -299,5 +310,34 @@ struct DisplayConfiguratorTests {
         #expect(call.display == externalID)
         #expect(call.x == 1440)
         #expect(call.y == -270)
+    }
+
+    @Test("Unmirror path uses passed-in resolution, not stale displayBounds")
+    func extendUnmirrorUsesPassedResolution() {
+        let mock = makeTransactor()
+        mock.mirrorSetDisplays.insert(externalID)
+        // Simulate stale bounds: mock returns MacBook-sized bounds for external
+        // (what CGDisplayBounds would return before macOS settles after unmirror)
+        mock.boundsMap[externalID] = internalBounds
+
+        let realResolution = CGSize(width: 3840, height: 1600)
+        let config = makeConfig(mode: .extend, preset: .externalAbove)
+
+        DisplayConfigurator.apply(
+            config,
+            primaryID: primaryID,
+            externalID: externalID,
+            externalResolution: realResolution,
+            transactor: mock,
+            logger: logger
+        )
+
+        #expect(mock.originCalls.count == 1)
+        let call = mock.originCalls[0]
+        // Should use realResolution (3840×1600), not stale internalBounds (1440×900)
+        // x = (1440/2 - 3840/2) = -1200
+        // y = (0 - 1600) = -1600
+        #expect(call.x == -1200)
+        #expect(call.y == -1600)
     }
 }

--- a/Tests/SnapTests/DisplayConfiguratorTests.swift
+++ b/Tests/SnapTests/DisplayConfiguratorTests.swift
@@ -78,7 +78,10 @@ struct DisplayConfiguratorTests {
     private let externalID: CGDirectDisplayID = 2
     private let internalBounds = CGRect(x: 0, y: 0, width: 1440, height: 900)
     private let externalBounds = CGRect(x: 0, y: 0, width: 2560, height: 1440)
-    private var externalResolution: CGSize { externalBounds.size }
+    private var externalResolution: CGSize {
+        externalBounds.size
+    }
+
     private let logger = SnapLogger(category: "Test", logStore: LogStore())
 
     private func makeTransactor() -> MockDisplayTransactor {


### PR DESCRIPTION
## Problem

When macOS connects a display in mirror mode (e.g. the DELL U3824DW), `applyExtend()` correctly unmirrors first in a separate CGDisplay transaction, then reads `CGDisplayBounds(externalID)` for the positioning calculation. But macOS hasn't finished settling the display geometry yet, so `CGDisplayBounds` returns stale mirrored dimensions — producing wrong placement on first apply. Retriggering works because the display is already unmirrored.

**Observed in logs:** Display connected with `mirror=1`, Snap unmirrors + positions immediately, arrangement is wrong. User retriggers → works correctly.

## Root cause

Race condition in `DisplayConfigurator.applyExtend()`: after the unmirror `completeConfiguration` commits, `CGDisplayBounds` is called immediately but returns the pre-unmirror (mirrored) geometry.

## Fix

Pass the already-known external resolution (`CGSize`) from the caller — both `displayDidConnect()` and `applyAndSave()` already have it — instead of reading `CGDisplayBounds(externalID)` post-unmirror. The internal display bounds are unaffected and still read from `CGDisplayBounds`.

This is a synchronous, zero-delay fix with no timing dependencies.

## Changes

- **`DisplayConfigurator.swift`** — Added `externalResolution: CGSize` parameter to `apply()` and `applyExtend()`; uses it instead of `transactor.displayBounds(externalID)`
- **`AppDelegate.swift`** — Passes `resolution` at both call sites
- **`DisplayConfiguratorTests.swift`** — Updated all existing `apply()` calls; added test verifying the unmirror path uses passed-in resolution over stale `displayBounds`

## Testing

All 70 tests pass. New test `extendUnmirrorUsesPassedResolution` sets the mock's external bounds to MacBook-sized (simulating stale post-unmirror values) and verifies positioning uses the caller-supplied 3840×1600 instead.