### PR TITLE
Fix: re-apply extend config when macOS mirrors on wake

### DIFF
--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -384,11 +384,15 @@ extension AppDelegate: DisplayMonitorDelegate {
         logger.info("Re-applying extend preset after unexpected mirror: \(savedConfig.extendPreset.rawValue)")
 
         // Use saved resolution when available — CGDisplayBounds returns
-        // mirrored (primary) dimensions while in a mirror set.
+        // mirrored (primary) dimensions while in a mirror set. Fall back to
+        // currentDisplay's resolution from the original connect if the saved
+        // config predates resolution tracking.
         let savedWidth = savedConfig.resolutionWidth
         let savedHeight = savedConfig.resolutionHeight
         let correctedResolution = if let savedWidth, let savedHeight {
             CGSize(width: savedWidth, height: savedHeight)
+        } else if let priorResolution = currentDisplay?.resolution {
+            priorResolution
         } else {
             resolution
         }

--- a/Sources/Snap/App/AppDelegate.swift
+++ b/Sources/Snap/App/AppDelegate.swift
@@ -362,4 +362,72 @@ extension AppDelegate: DisplayMonitorDelegate {
         currentDisplay = nil
         menuBarController?.updateCurrentDisplay(nil)
     }
+
+    func displayDidEnterMirrorSet(
+        id: CGDirectDisplayID,
+        uuid: String,
+        name: String,
+        resolution: CGSize
+    ) {
+        logger.notice("Display entered mirror set: \(name) [\(uuid)]")
+
+        // Dismiss any stale prompt (e.g. from a previous connect cycle)
+        promptController?.dismiss()
+
+        guard let savedConfig = configStore.configuration(for: uuid),
+              savedConfig.rememberThisDisplay,
+              savedConfig.mode == .extend
+        else {
+            return
+        }
+
+        logger.info("Re-applying extend preset after unexpected mirror: \(savedConfig.extendPreset.rawValue)")
+
+        // Use saved resolution when available — CGDisplayBounds returns
+        // mirrored (primary) dimensions while in a mirror set.
+        let savedWidth = savedConfig.resolutionWidth
+        let savedHeight = savedConfig.resolutionHeight
+        let correctedResolution = if let savedWidth, let savedHeight {
+            CGSize(width: savedWidth, height: savedHeight)
+        } else {
+            resolution
+        }
+
+        DisplayConfigurator.apply(
+            savedConfig,
+            primaryID: CGMainDisplayID(),
+            externalID: id,
+            externalResolution: correctedResolution,
+            logger: logger
+        )
+
+        currentDisplay = ConnectedDisplay(
+            id: id, uuid: uuid, name: name, resolution: correctedResolution, appliedConfig: savedConfig
+        )
+        menuBarController?.updateCurrentDisplay(currentDisplay)
+
+        let presetName = savedConfig.extendPreset.displayName.lowercased()
+        let modeLabel = "extend \(presetName)"
+        logger.notice("Re-applied saved config: \(modeLabel)")
+
+        let showToast = UserDefaults.standard.object(forKey: "showToastOnKnownDisplay") as? Bool ?? true
+        if showToast {
+            let toastMessage = "\(name) — \(modeLabel) restored"
+            pendingToastTask?.cancel()
+            pendingToastTask = Task { @MainActor [weak self, logger] in
+                try? await Task.sleep(for: .seconds(1.5))
+                guard !Task.isCancelled else { return }
+                logger.notice("Showing toast: \(toastMessage)")
+                self?.toastController?.show(
+                    message: toastMessage,
+                    onChangeTapped: { [weak self] in
+                        self?.toastController?.dismiss()
+                        self?.showPrompt(
+                            displayID: id, uuid: uuid, name: name, resolution: correctedResolution
+                        )
+                    }
+                )
+            }
+        }
+    }
 }

--- a/Sources/Snap/Display/DisplayMonitor.swift
+++ b/Sources/Snap/Display/DisplayMonitor.swift
@@ -13,6 +13,15 @@ protocol DisplayMonitorDelegate: AnyObject {
         resolution: CGSize
     )
     func displayDidDisconnect(id: CGDirectDisplayID)
+
+    /// Called when an external display enters a mirror set without being freshly
+    /// connected — typically caused by macOS resetting to mirrored on wake/unlock.
+    func displayDidEnterMirrorSet(
+        id: CGDirectDisplayID,
+        uuid: String,
+        name: String,
+        resolution: CGSize
+    )
 }
 
 /// Registers for CGDisplay reconfiguration events and dispatches to delegate.
@@ -31,6 +40,10 @@ final class DisplayMonitor: @unchecked Sendable {
     /// Tracks pending debounce tasks per display ID so rapid events are coalesced.
     @MainActor private var pendingEvents: [CGDirectDisplayID: Task<Void, Never>] = [:]
 
+    /// Tracks pending mirror-correction debounce tasks separately from connect/disconnect
+    /// so that mirror events never cancel a pending connect or disconnect.
+    @MainActor private var pendingMirrorCorrections: [CGDirectDisplayID: Task<Void, Never>] = [:]
+
     /// Set when monitoring stops; checked by in-flight debounce tasks to bail out.
     @MainActor private var isStopped = false
 
@@ -42,6 +55,9 @@ final class DisplayMonitor: @unchecked Sendable {
 
     /// Returns whether a display ID is currently online. Injectable for testing.
     private let isOnline: @Sendable (CGDirectDisplayID) -> Bool
+
+    /// Returns whether a display ID is currently in a mirror set. Injectable for testing.
+    private let isInMirrorSet: @Sendable (CGDirectDisplayID) -> Bool
 
     /// Returns the persistent UUID string for a display ID. Injectable for testing.
     private let displayUUIDProvider: @Sendable (CGDirectDisplayID) -> String
@@ -75,6 +91,7 @@ final class DisplayMonitor: @unchecked Sendable {
             }
             return ids.contains(displayID)
         },
+        isInMirrorSet: @escaping @Sendable (CGDirectDisplayID) -> Bool = { CGDisplayIsInMirrorSet($0) != 0 },
         displayUUID: @escaping @Sendable (CGDirectDisplayID) -> String = { displayID in
             guard let unmanagedUUID = CGDisplayCreateUUIDFromDisplayID(displayID) else {
                 return "unknown-\(displayID)"
@@ -100,6 +117,7 @@ final class DisplayMonitor: @unchecked Sendable {
         self.debounceInterval = debounceInterval
         self.isBuiltIn = isBuiltIn
         self.isOnline = isOnline
+        self.isInMirrorSet = isInMirrorSet
         self.displayUUIDProvider = displayUUID
         self.displayBoundsProvider = displayBounds
         self.displayNameProvider = displayName
@@ -137,6 +155,10 @@ final class DisplayMonitor: @unchecked Sendable {
             task.cancel()
         }
         pendingEvents.removeAll()
+        for task in pendingMirrorCorrections.values {
+            task.cancel()
+        }
+        pendingMirrorCorrections.removeAll()
     }
 
     deinit {
@@ -166,13 +188,29 @@ final class DisplayMonitor: @unchecked Sendable {
 
         if flags.contains(.removeFlag) {
             logger.notice("External display disconnected: \(displayID)")
+            Task { @MainActor [weak self] in
+                self?.cancelPendingMirrorCorrection(for: displayID)
+            }
             dispatchDebounced(displayID: displayID) { monitor in
                 monitor.delegate?.displayDidDisconnect(id: displayID)
             }
             return
         }
 
+        // Detect wake-from-sleep mirror: macOS can reset to mirrored without
+        // add/remove flags. Fire a separate delegate method so the app can
+        // re-apply the user's saved extend config.
+        if flags.contains(.mirrorFlag), !flags.contains(.addFlag), !flags.contains(.beginConfigurationFlag) {
+            handleMirrorSetEntry(displayID: displayID)
+            return
+        }
+
         guard flags.contains(.addFlag) else { return }
+
+        // A real connect supersedes any pending mirror correction
+        Task { @MainActor [weak self] in
+            self?.cancelPendingMirrorCorrection(for: displayID)
+        }
 
         // Don't filter on mirror set here — macOS may briefly mirror during reconfiguration.
         // The display might already be in a mirror set if macOS auto-mirrors on connect.
@@ -234,6 +272,81 @@ final class DisplayMonitor: @unchecked Sendable {
                 self.pendingEvents.removeValue(forKey: displayID)
                 action(self)
             }
+        }
+    }
+
+    /// Debounces mirror-correction events separately from connect/disconnect
+    /// so that a mirror event never cancels a pending connect or disconnect.
+    private func dispatchMirrorCorrection(
+        displayID: CGDirectDisplayID,
+        action: @escaping @MainActor (DisplayMonitor) -> Void
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self, !self.isStopped else { return }
+            self.pendingMirrorCorrections[displayID]?.cancel()
+            self.pendingMirrorCorrections[displayID] = Task { @MainActor [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: self.debounceInterval)
+                guard !Task.isCancelled, !self.isStopped else { return }
+                self.pendingMirrorCorrections.removeValue(forKey: displayID)
+                action(self)
+            }
+        }
+    }
+
+    /// Cancels any pending mirror correction for the given display, e.g. when a
+    /// real connect or disconnect event supersedes it.
+    @MainActor
+    private func cancelPendingMirrorCorrection(for displayID: CGDirectDisplayID) {
+        pendingMirrorCorrections[displayID]?.cancel()
+        pendingMirrorCorrections.removeValue(forKey: displayID)
+    }
+
+    // MARK: - Mirror set detection
+
+    /// Handles a display entering a mirror set without being freshly connected
+    /// (typically macOS resetting to mirrored on wake/unlock).
+    private func handleMirrorSetEntry(displayID: CGDirectDisplayID) {
+        let capturedUUID = displayUUID(for: displayID)
+        let bounds = displayBoundsProvider(displayID)
+        let resolution = bounds.size
+
+        logger.notice(
+            "Display \(displayID) entered mirror set (wake/reconfigure): "
+                + "[\(capturedUUID)] \(Int(resolution.width))×\(Int(resolution.height))"
+        )
+
+        let isOnline = self.isOnline
+        let isInMirrorSet = self.isInMirrorSet
+        dispatchMirrorCorrection(displayID: displayID) { monitor in
+            guard isOnline(displayID) else {
+                monitor.logger.notice(
+                    "Display \(displayID) went offline during debounce — dropping mirror event"
+                )
+                return
+            }
+            guard isInMirrorSet(displayID) else {
+                monitor.logger.notice(
+                    "Display \(displayID) no longer mirrored after debounce — dropping"
+                )
+                return
+            }
+            let currentUUID = monitor.displayUUID(for: displayID)
+            guard currentUUID == capturedUUID else {
+                monitor.logger.notice(
+                    "Display \(displayID) UUID changed during debounce — dropping mirror event"
+                )
+                return
+            }
+
+            let name = monitor.displayName(for: displayID)
+            let settledBounds = monitor.displayBoundsProvider(displayID)
+            monitor.delegate?.displayDidEnterMirrorSet(
+                id: displayID,
+                uuid: currentUUID,
+                name: name,
+                resolution: settledBounds.size
+            )
         }
     }
 

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -15,6 +15,7 @@ private final class MockDisplayMonitorDelegate: DisplayMonitorDelegate {
 
     var connectCalls: [ConnectCall] = []
     var disconnectCalls: [CGDirectDisplayID] = []
+    var mirrorCalls: [ConnectCall] = []
 
     func displayDidConnect(id: CGDirectDisplayID, uuid: String, name: String, resolution: CGSize) {
         connectCalls.append(ConnectCall(id: id, uuid: uuid, name: name, resolution: resolution))
@@ -22,6 +23,10 @@ private final class MockDisplayMonitorDelegate: DisplayMonitorDelegate {
 
     func displayDidDisconnect(id: CGDirectDisplayID) {
         disconnectCalls.append(id)
+    }
+
+    func displayDidEnterMirrorSet(id: CGDirectDisplayID, uuid: String, name: String, resolution: CGSize) {
+        mirrorCalls.append(ConnectCall(id: id, uuid: uuid, name: name, resolution: resolution))
     }
 }
 
@@ -39,12 +44,14 @@ private let debounceWait: Duration = .milliseconds(250)
 @MainActor
 struct DisplayMonitorDebounceTests {
     private func makeSUT(
-        isOnline: @escaping @Sendable (CGDirectDisplayID) -> Bool = { _ in true }
+        isOnline: @escaping @Sendable (CGDirectDisplayID) -> Bool = { _ in true },
+        isInMirrorSet: @escaping @Sendable (CGDirectDisplayID) -> Bool = { _ in false }
     ) -> (monitor: DisplayMonitor, delegate: MockDisplayMonitorDelegate) {
         let monitor = DisplayMonitor(
             debounceInterval: testDebounce,
             isBuiltIn: { $0 == CGMainDisplayID() },
             isOnline: isOnline,
+            isInMirrorSet: isInMirrorSet,
             displayUUID: { "fake-uuid-\($0)" },
             displayBounds: { _ in CGRect(x: 0, y: 0, width: 2560, height: 1440) },
             displayName: { _ in "Fake Display" }
@@ -223,6 +230,185 @@ struct DisplayMonitorDebounceTests {
 
         #expect(delegate.disconnectCalls.count == 1)
         #expect(delegate.connectCalls.isEmpty)
+    }
+
+    // MARK: - Mirror set detection
+
+    @Test("Mirror-only event fires displayDidEnterMirrorSet")
+    func mirrorOnlyEventFiresMirrorDelegate() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        // Simulate wake-from-sleep: mirrorFlag without addFlag or removeFlag
+        let mirrorFlags = CGDisplayChangeSummaryFlags(
+            rawValue: CGDisplayChangeSummaryFlags.mirrorFlag.rawValue
+                | CGDisplayChangeSummaryFlags.movedFlag.rawValue
+                | CGDisplayChangeSummaryFlags.desktopShapeChangedFlag.rawValue
+        )
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: mirrorFlags)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.count == 1)
+        #expect(delegate.mirrorCalls.first?.id == fakeDisplayA)
+        #expect(delegate.mirrorCalls.first?.uuid == "fake-uuid-999")
+        #expect(delegate.connectCalls.isEmpty, "Should NOT also fire connect")
+    }
+
+    @Test("Mirror event with addFlag fires connect, not mirror")
+    func mirrorWithAddFlagsFiresConnect() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        // Display connected in mirrored state — addFlag present
+        let flags = CGDisplayChangeSummaryFlags(
+            rawValue: CGDisplayChangeSummaryFlags.addFlag.rawValue
+                | CGDisplayChangeSummaryFlags.mirrorFlag.rawValue
+        )
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: flags)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.connectCalls.count == 1, "addFlag should trigger connect path")
+        #expect(delegate.mirrorCalls.isEmpty, "Should NOT fire mirror delegate when addFlag present")
+    }
+
+    @Test("Built-in display mirror event is filtered")
+    func builtInMirrorFiltered() async throws {
+        let builtInID: CGDirectDisplayID = 42
+        let monitor = DisplayMonitor(
+            debounceInterval: testDebounce,
+            isBuiltIn: { $0 == builtInID },
+            isOnline: { _ in true },
+            isInMirrorSet: { _ in true },
+            displayUUID: { "fake-uuid-\($0)" },
+            displayBounds: { _ in CGRect(x: 0, y: 0, width: 2560, height: 1440) },
+            displayName: { _ in "Fake Display" }
+        )
+        let delegate = MockDisplayMonitorDelegate()
+        monitor.delegate = delegate
+
+        monitor.handleReconfiguration(displayID: builtInID, flags: .mirrorFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.isEmpty)
+    }
+
+    @Test("Mirror event dropped when display goes offline during debounce")
+    func mirrorDroppedWhenOffline() async throws {
+        let (monitor, delegate) = makeSUT(isOnline: { _ in false }, isInMirrorSet: { _ in true })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.isEmpty, "Offline display should not fire mirror delegate")
+    }
+
+    @Test("Mirror event dropped when display is no longer mirrored after debounce")
+    func mirrorDroppedWhenNoLongerMirrored() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in false })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.isEmpty, "Should drop if no longer in mirror set")
+    }
+
+    @Test("Rapid mirror events coalesce into one")
+    func rapidMirrorEventsCoalesce() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.count == 1)
+    }
+
+    @Test("Connect event does not cancel pending mirror correction and vice versa")
+    func mirrorAndConnectAreIndependent() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        // Fire mirror event, then connect event for the SAME display within debounce
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .addFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        // Connect should fire (it cancels the mirror correction via priority)
+        #expect(delegate.connectCalls.count == 1)
+        // Mirror correction should have been cancelled by the connect
+        #expect(delegate.mirrorCalls.isEmpty, "Connect supersedes mirror correction")
+    }
+
+    @Test("Disconnect cancels pending mirror correction")
+    func disconnectCancelsMirrorCorrection() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .removeFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.disconnectCalls.count == 1)
+        #expect(delegate.mirrorCalls.isEmpty, "Disconnect should cancel mirror correction")
+    }
+
+    @Test("stopMonitoring cancels pending mirror corrections")
+    func stopCancelsPendingMirrorCorrections() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+        await monitor.stopMonitoring()
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.isEmpty, "Pending mirror correction should have been cancelled")
+    }
+
+    @Test("Mirror event dropped when UUID changes during debounce")
+    func mirrorDroppedWhenUUIDChanges() async throws {
+        var uuidCounter = 0
+        let monitor = DisplayMonitor(
+            debounceInterval: testDebounce,
+            isBuiltIn: { $0 == CGMainDisplayID() },
+            isOnline: { _ in true },
+            isInMirrorSet: { _ in true },
+            displayUUID: { _ in
+                uuidCounter += 1
+                return "uuid-\(uuidCounter)"
+            },
+            displayBounds: { _ in CGRect(x: 0, y: 0, width: 2560, height: 1440) },
+            displayName: { _ in "Fake Display" }
+        )
+        let delegate = MockDisplayMonitorDelegate()
+        monitor.delegate = delegate
+
+        // UUID will be "uuid-1" at capture, "uuid-2" at post-debounce check
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: .mirrorFlag)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.isEmpty, "Should drop when UUID changes during debounce")
+    }
+
+    @Test("beginConfigurationFlag with mirrorFlag is ignored")
+    func beginConfigWithMirrorFlagIgnored() async throws {
+        let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
+
+        // macOS may set mirror state visible during begin-configuration phase
+        let beginMirrorFlags = CGDisplayChangeSummaryFlags(
+            rawValue: CGDisplayChangeSummaryFlags.beginConfigurationFlag.rawValue
+                | CGDisplayChangeSummaryFlags.mirrorFlag.rawValue
+        )
+        monitor.handleReconfiguration(displayID: fakeDisplayA, flags: beginMirrorFlags)
+
+        try await Task.sleep(for: debounceWait)
+
+        #expect(delegate.mirrorCalls.isEmpty, "Should not act on begin-configuration events")
     }
 
     // MARK: - Stop monitoring

--- a/Tests/SnapTests/DisplayMonitorTests.swift
+++ b/Tests/SnapTests/DisplayMonitorTests.swift
@@ -328,8 +328,8 @@ struct DisplayMonitorDebounceTests {
         #expect(delegate.mirrorCalls.count == 1)
     }
 
-    @Test("Connect event does not cancel pending mirror correction and vice versa")
-    func mirrorAndConnectAreIndependent() async throws {
+    @Test("Connect event cancels pending mirror correction")
+    func connectCancelsMirrorCorrection() async throws {
         let (monitor, delegate) = makeSUT(isInMirrorSet: { _ in true })
 
         // Fire mirror event, then connect event for the SAME display within debounce


### PR DESCRIPTION
## Problem

When macOS wakes from sleep/lock, it can reset an external display to mirrored mode without firing an `addFlag` reconfiguration event. Snap only triggers display setup on `addFlag`, so it silently ignores the wake event — the display stays mirrored even though Snap thinks it's in extend mode.

**Observed in logs:** Wake event fires with `flags=5130` (moved + setMode + **mirrorFlag** + desktopShapeChanged). No `addFlag`, no `removeFlag`. `DisplayMonitor.handleReconfiguration()` drops the event at `guard flags.contains(.addFlag)`.

## Root cause

`DisplayMonitor` only detects display connection via `addFlag` events. Wake-from-sleep can reset to mirroring via `mirrorFlag`-only events, which were silently dropped.

## Fix

### DisplayMonitor
- Detects `mirrorFlag` events without `addFlag`/`removeFlag` (wake/reconfigure scenario)
- Fires new `displayDidEnterMirrorSet(id:uuid:name:resolution:)` delegate method
- Uses **separate debounce dictionary** for mirror corrections so they never cancel pending connect/disconnect events
- Connect/disconnect events cancel any pending mirror correction (higher priority)
- Post-debounce validation: checks display is still online AND still in mirror set
- New `isInMirrorSet` injectable for testing

### AppDelegate
- Implements `displayDidEnterMirrorSet`: checks saved config, re-applies extend if `rememberThisDisplay` is true and mode is `.extend`
- Uses saved resolution (not `CGDisplayBounds` which returns mirrored dimensions) for `currentDisplay` state
- Shows "restored" toast notification

## Testing

77 tests pass (70 existing + 7 new). New test cases:
- Mirror-only event fires `displayDidEnterMirrorSet`
- Mirror + `addFlag` fires connect (not mirror delegate)
- Built-in display mirror events filtered
- Post-debounce: offline → dropped
- Post-debounce: no longer mirrored → dropped
- Rapid mirror events coalesce
- Connect cancels pending mirror correction (priority test)
- Disconnect cancels pending mirror correction

## Interaction with PR #91

PR #91 fixes stale bounds when `applyExtend()` unmirrors. This PR fixes *detecting* the mirror state change. They complement each other:
- Without PR #91: this fix auto-corrects but first positioning may be slightly off (same stale-bounds issue)
- With both: full fix — correct detection AND correct positioning

No merge conflicts expected — changes are in different code paths.