### PR TITLE
fix: DMG drag-to-install + CHANGELOG-based release notes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,6 +66,20 @@ Scripts/generate-review-instructions.sh --check # verify freshness (CI)
 - Sparkle 2 for auto-updates (SPM dependency).
 - `LSUIElement = true` — menu bar only, no Dock icon.
 
+### Release pipeline
+- Tagging `v*` triggers `.github/workflows/release.yml`:
+  archive → DMG → Sparkle EdDSA sign → GitHub Release → website dispatch.
+- The app is **ad-hoc signed for now** (no Developer ID, not notarized — TODO #19).
+  Until then, fresh installs need `xattr -dr com.apple.quarantine /Applications/Snap.app`.
+- The DMG is staged with the app **plus an `/Applications` symlink** so users can
+  drag-to-install — never build the DMG straight from the bare `.app`.
+- **Release notes come from the matching `CHANGELOG.md` section** (Keep a Changelog),
+  extracted by the `publish` job. A tag with no CHANGELOG entry **fails the release**.
+- **The Sparkle appcast lives in the website repo** (`steamedhams.au/projects/snap/appcast.xml`)
+  and is updated automatically via `repository_dispatch` (`notify-website` job, payload =
+  signature/length/version/build/pubdate). **Never put appcast XML in the GitHub release
+  body** — the website is the source of truth, not the release page.
+
 ## Testing
 - Swift Testing framework for all new tests (not XCTest).
 - Mock display APIs via protocols for unit testing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,14 @@ jobs:
       - name: Create DMG
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          STAGE="build/dmg"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          cp -R build/export/Snap.app "$STAGE/Snap.app"
+          ln -s /Applications "$STAGE/Applications"
           hdiutil create \
             -volname "Snap ${VERSION}" \
-            -srcfolder build/export/Snap.app \
+            -srcfolder "$STAGE" \
             -ov \
             -format UDZO \
             "build/Snap-${VERSION}.dmg"
@@ -174,32 +179,29 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           name: Snap-${{ steps.version.outputs.version }}.dmg
 
       - name: Build release body
-        id: body
         run: |
-          if [ -f appcast-snippet.xml ]; then
-            {
-              echo "### Appcast Update"
-              echo ""
-              echo 'Add this `<item>` to `appcast.xml` in the website repo:'
-              echo ""
-              echo '```xml'
-              cat appcast-snippet.xml
-              echo '```'
-            } > release-body.md
-          else
-            touch release-body.md
+          VERSION="${{ steps.version.outputs.version }}"
+          awk -v v="$VERSION" '
+            index($0, "## [" v "]") == 1 { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-body.md
+          if [ ! -s release-body.md ]; then
+            echo "::error::No CHANGELOG.md section found for ${VERSION}" >&2
+            exit 1
           fi
-          {
-            echo "body<<GHEOF"
-            cat release-body.md
-            echo "GHEOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "────── Release body ──────"
+          cat release-body.md
+          echo "──────────────────────────"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -208,13 +210,18 @@ jobs:
           tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          body: ${{ steps.body.outputs.body }}
+          body_path: release-body.md
           files: Snap-${{ steps.version.outputs.version }}.dmg
           generate_release_notes: true
 
   notify-website:
     name: Update website appcast
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.archive.outputs.ed_signature != '' &&
+      needs.archive.outputs.length != '' &&
+      needs.archive.outputs.build_version != '' &&
+      needs.archive.outputs.pub_date != ''
     needs: [archive, publish]
     runs-on: ubuntu-latest
     environment: website-deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Snap will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- Release DMG now includes an `/Applications` symlink so the app can be dragged straight into Applications
+
+### Changed
+
+- GitHub Release notes are now generated from the matching `CHANGELOG.md` section; the Sparkle appcast XML is no longer embedded in the release body (the website appcast is still updated automatically via repository dispatch)
+
 ## [0.4.2-beta] — 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,19 @@ That's it. One interaction, then it's invisible.
 
 ## Install
 
-> Releases coming soon. For now, build from source.
+### Download (recommended)
+
+1. Download the latest `Snap-x.y.z.dmg` from the [Releases page](https://github.com/SteamedHamsAU/snap/releases).
+2. Open the DMG and drag **Snap** onto the **Applications** folder.
+3. Snap isn't notarized yet, so macOS Gatekeeper quarantines it on first launch. Clear the flag once:
+
+   ```bash
+   xattr -dr com.apple.quarantine /Applications/Snap.app
+   ```
+
+4. Launch Snap from Applications — it lives in the menu bar (no Dock icon).
+
+### Build from source
 
 ```bash
 brew install xcodegen swiftformat swiftlint xcbeautify


### PR DESCRIPTION
## What & why

Two distribution issues, plus supporting docs.

### 1. DMG had no `/Applications` shortcut
The release built the DMG straight from the bare `Snap.app`, so the mounted volume had nowhere to drag the app. The `Create DMG` step now stages the app alongside an `/Applications` symlink before `hdiutil create`, so drag-to-install works.

### 2. Release body led with Sparkle appcast XML and no change summary
The body embedded the appcast `<item>` XML with "add this to the website repo" instructions, then only a "Full Changelog" link — it never outlined what changed.

**Pipeline-safe:** the website appcast (`steamedhams.au/projects/snap/appcast.xml`) is updated automatically via the `notify-website` **`repository_dispatch`** job (payload = signature/length/version/build/pubdate), **not** by scraping the release body. So the XML is redundant and safe to drop. The archive job's Sparkle signing + appcast-snippet generation/upload are untouched.

The `publish` job now:
- checks out the repo **before** `download-artifact` (checkout cleans the workspace),
- extracts the matching `CHANGELOG.md` section via fixed-string `awk`,
- **fails the release** if there's no section for the tag,
- passes it via `body_path`, keeping `generate_release_notes: true` for the auto "Full Changelog" link.

### Hardening
`notify-website` now has an `if:` guard so it skips the website dispatch when the Sparkle outputs are empty (e.g. an unsigned build with no `SPARKLE_EDDSA_KEY`), avoiding an empty appcast payload.

### Docs
- `.github/copilot-instructions.md` `## Distribution` documents the pipeline and that the appcast lives in the website repo — never in the release body.
- README Install rewritten: download from Releases, drag to Applications, `xattr -dr com.apple.quarantine /Applications/Snap.app` (unsigned/un-notarized for now — #19).
- `CHANGELOG.md` `[Unreleased]` entry added.

## Validation
- ✅ YAML parses; `actionlint` clean on `release.yml`
- ✅ `awk` extraction returns the correct section for `0.4.2-beta`; a non-existent version yields empty output → triggers the `exit 1` fail path
- ✅ Built a staged DMG locally, mounted it, confirmed both `Snap.app` and the `Applications -> /Applications` symlink appear

No Swift code touched — workflow + docs only.
